### PR TITLE
Added note about Android for Maven Eclipse.

### DIFF
--- a/source/eclipse-quick-start.md
+++ b/source/eclipse-quick-start.md
@@ -6,6 +6,8 @@ title: Eclipse Quick Start
 ##Quick Start for Eclipse
 --- 
 
+_Note:_ If you're using [Maven](http://maven.apache.org/) as your build tool you can include Robolectric tests in the same project as your application code without any additional configuration using the [Android for Maven Eclipse](http://rgladwell.github.io/m2e-android/) plugin.
+
 ###Download JARs
 You'll need at least the "robolectric-x.x.x-jar-with-dependencies" jar, which can be obtained [here](/download/). You may also want the source jar matching your Robolectric version from the same location, in case you run in to any bugs. Also recommended, but not required, is the [latest hamcrest-all jar](https://code.google.com/p/hamcrest/downloads/list).
  


### PR DESCRIPTION
The Android for Maven Eclipse (m2e-android) plugin now includes support for
Robolectric and other unit testing frameworks. Additionally, it now allows you
to have unit tests and application code in the same project:

https://github.com/rgladwell/m2e-android/issues/52

This commit adds a note for Eclipse users to this effect, pointing them in the
direction of the plugin.
