### PR TITLE
Fix dependency declaration for Android Studio 3.0+

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -17,7 +17,7 @@ Starting with Robolectric 3.3 there is now tighter integration with the tool cha
 Add the following to your build.gradle:
 
 ```groovy
-testCompile "org.robolectric:robolectric:{{ site.robolectric.version.current | escape }}"
+testImplementation "org.robolectric:robolectric:{{ site.robolectric.version.current | escape }}"
 
 android {
   testOptions {


### PR DESCRIPTION
@brettchabot: @jongerrish asked me to PR for this change a while back in https://github.com/robolectric/robolectric/issues/3169#issuecomment-324747838. It just updates the setup instructions to use the new dependency APIs in AGP 3.0+.