### PR TITLE
Update documentation according to new API

### DIFF
--- a/activity-lifecycle.md
+++ b/activity-lifecycle.md
@@ -50,7 +50,7 @@ You can simulate starting the Activity with an intent:
 
 ```java
 Intent intent = new Intent(Intent.ACTION_VIEW);
-Activity activity = Robolectric.buildActivity(MyAwesomeActivity.class).withIntent(intent).create().get();
+Activity activity = Robolectric.buildActivity(MyAwesomeActivity.class, intent).create().get();
 ```
 
 ... or restore saved instance state:


### PR DESCRIPTION
Documentation currently refers to ActivityController#withIntent(Intent) which was removed here: https://github.com/robolectric/robolectric/commit/582530917f13cef209225ce455ba5e4684d7b32d

Example now uses buildIntent(class, Intent).