### PR TITLE
Update dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3.4)
+    activesupport (6.0.3.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -34,8 +34,8 @@ GEM
     ffi (1.14.2)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
-    github-pages (210)
-      github-pages-health-check (= 1.16.1)
+    github-pages (212)
+      github-pages-health-check (= 1.17.0)
       jekyll (= 3.9.0)
       jekyll-avatar (= 0.7.0)
       jekyll-coffeescript (= 1.1.1)
@@ -76,13 +76,13 @@ GEM
       mercenary (~> 0.3)
       minima (= 2.5.1)
       nokogiri (>= 1.10.4, < 2.0)
-      rouge (= 3.23.0)
+      rouge (= 3.26.0)
       terminal-table (~> 1.4)
-    github-pages-health-check (1.16.1)
+    github-pages-health-check (1.17.0)
       addressable (~> 2.3)
       dnsruby (~> 1.60)
       octokit (~> 4.0)
-      public_suffix (~> 3.0)
+      public_suffix (>= 2.0.2, < 5.0)
       typhoeus (~> 1.3)
     html-pipeline (2.14.0)
       activesupport (>= 2)
@@ -210,7 +210,7 @@ GEM
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    minitest (5.14.3)
+    minitest (5.14.4)
     multipart-post (2.1.1)
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
@@ -220,14 +220,14 @@ GEM
       sawyer (~> 0.8.0, >= 0.5.3)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (3.1.1)
+    public_suffix (4.0.6)
     racc (1.5.2)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.4)
-    rouge (3.23.0)
-    ruby-enum (0.8.0)
+    rouge (3.26.0)
+    ruby-enum (0.9.0)
       i18n
     ruby2_keywords (0.0.4)
     rubyzip (2.3.0)
@@ -259,14 +259,14 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  github-pages (= 210)
+  github-pages (= 212)
   jekyll
   jekyll-feed (~> 0.6)
   jekyll-redirect-from
   tzinfo-data
 
 RUBY VERSION
-   ruby 2.7.2p137
+   ruby 2.7.0p0
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
When I execute `bundle install`, it shows the following error:

Bundler could not find compatible versions for gem "rouge":
  In snapshot (Gemfile.lock):
    rouge (= 3.23.0)

  In Gemfile:
    github-pages (= 212) was resolved to 212, which depends on
      rouge (= 3.26.0)

    jekyll was resolved to 3.9.0, which depends on
      rouge (>= 1.7, < 4)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.

So I use it recommendation to execute `bundle update` to update
dependencies of jekyll to fix this error.

Actually, the better choice is to install [GitHub's dependabot](https://github.com/marketplace/dependabot-preview)
to update dependencies automatically.