### PR TITLE
Update examples to use ActivityController#close

### DIFF
--- a/index.md
+++ b/index.md
@@ -16,11 +16,13 @@ public class MyActivityTest {
 
   @Test
   public void clickingButton_shouldChangeMessage() {
-    MyActivity activity = Robolectric.setupActivity(MyActivity.class);
+    try (ActivityController<MyActvitiy> controller = Robolectric.buildActivity(MyActvitiy.class)) {
+      controller.setup(); // Moves Activity to RESUMED state
+      MyActvitiy activity = controller.get();
 
-    activity.button.performClick();
-
-    assertThat(activity.message.getText()).isEqualTo("Robolectric Rocks!");
+      activity.findViewById(R.id.button).performClick();
+      assertEquals(((TextView) activity.findViewById(R.id.text)).getText(), "Robolectric Rocks!");
+    }
   }
 }
 ```

--- a/writing-a-test.md
+++ b/writing-a-test.md
@@ -53,12 +53,15 @@ public class WelcomeActivityTest {
 
     @Test
     public void clickingLogin_shouldStartLoginActivity() {
-        WelcomeActivity activity = Robolectric.setupActivity(WelcomeActivity.class);
-        activity.findViewById(R.id.login).performClick();
+        try (ActivityController<WelcomeActivity> controller = Robolectric.buildActivity(WelcomeActivity.class)) {
+            controller.setup(); // Moves Activity to RESUMED state
+            WelcomeActivity activity = controller.get();
 
-        Intent expectedIntent = new Intent(activity, LoginActivity.class);
-        Intent actual = shadowOf(RuntimeEnvironment.application).getNextStartedActivity();
-        assertEquals(expectedIntent.getComponent(), actual.getComponent());
+            activity.findViewById(R.id.login).performClick();
+            Intent expectedIntent = new Intent(activity, LoginActivity.class);
+            Intent actual = shadowOf(RuntimeEnvironment.application).getNextStartedActivity();
+            assertEquals(expectedIntent.getComponent(), actual.getComponent());
+        }
     }
 }
 ```


### PR DESCRIPTION
Closes robolectric/robolectric#7041

As discussed in the issue, the examples needed to be updated so that it's clear that `close()` should be called. We could also add a note to Best Practices around this, but I wanted to start with making sure the code examples are up to date.