### PR TITLE
Fix typo in `assetDir` keyword in @Config docs

### DIFF
--- a/build-system-integration.md
+++ b/build-system-integration.md
@@ -6,7 +6,7 @@ order: 2
 
 # Build System Integration
 
-Starting with Robolectric 3.3, the test runner will look for a file named `/com/android/tools/test_config.properties` on the classpath. If it is found, it will be used to provide the default manifest, resource, and asset locations for tests, without the need to specify `@Config(constants=BuildConfig.class)` or `@Config(manifest="...", res="...", assets="...")` in your tests.
+Starting with Robolectric 3.3, the test runner will look for a file named `/com/android/tools/test_config.properties` on the classpath. If it is found, it will be used to provide the default manifest, resource, and asset locations for tests, without the need to specify `@Config(constants=BuildConfig.class)` or `@Config(manifest="...", res="...", assetDir="...")` in your tests.
 
 This gives build system implementors the ability to perform manifest, asset and resource preprocessing and merging for tests using the same strategy it would when building the APK, rather than leaving it up to Robolectric.
 


### PR DESCRIPTION
See issue https://github.com/robolectric/robolectric.github.io/issues/121.

The `@Config` option is `assetDir`: http://robolectric.org/javadoc/latest/org/robolectric/annotation/Config.html#assetDir()