### PR TITLE
Remove unused build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Robolectric
 
-[![Build Status](https://secure.travis-ci.org/robolectric/robolectric.github.io.png?branch=master)](http://travis-ci.org/robolectric/robolectric.github.io)
-
 This repository is the source for the docs that live at [robolectric.org](http://robolectric.org).
 
 ## Contributing


### PR DESCRIPTION
AFAIK , we don't travis now, and we don't need this travis build status.