### PR TITLE
Enable dependabot updating for bundler ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: weekly


### PR DESCRIPTION
Integrate dependabot for Jekyll's bundler ecosystem.