### PR TITLE
Update building robolectric page

### DIFF
--- a/building-robolectric.md
+++ b/building-robolectric.md
@@ -70,7 +70,7 @@ Install the 64 bit version of msys2. You can follow the instructions at https://
 
 ### Building
 
-Open an msys2 terminal by running the "MSYS2 MinGW x64" shortcut. This will ensure that `/mingw64/bin` is on the PATH.
+Open an msys2 terminal by running the "MSYS2 MINGW64" shortcut. This will ensure that `/mingw64/bin` is on the PATH.
 
 ```
 pacman -Syu # Update system

--- a/building-robolectric.md
+++ b/building-robolectric.md
@@ -14,8 +14,8 @@ JDK 11 is currently recommended to build Robolectric. Newer versions of the JDK 
 ## Installing Android SDK Tools
 
 The first step is to install the Android SDK tools. The easiest way to do this is to install Android Studio, which also installs a copy of the
-Android SDK tools, and provides the SDK Manager UI to manage SDK versions. Alternatively is also possible to only download the Android command line tools without
-installing the entire Android Studio. However, it is recommended to install Android Studio if possible. Visit https://developer.android.com/studio#download to get started.
+Android SDK tools, and provides the SDK Manager UI to manage SDK versions. Alternatively it is also possible to only download the Android command line tools without
+installing the entire Android Studio. However, it is recommended to install Android Studio if possible. Visit [https://developer.android.com/studio#download](https://developer.android.com/studio#download) to get started.
 
 Many of Robolectric's [integration tests](https://github.com/robolectric/robolectric/tree/master/integration_tests)
 require the Android build tools to be installed and specific SDK versions to be installed.


### PR DESCRIPTION
Hey! I was trying to build Robolectric (re: https://github.com/robolectric/robolectric/issues/7963) in Windows and noticed some updates that could be made to the building page. I changed the following:

- Added an explicit link https://developer.android.com/studio#download, since it wasn't showing as a clickable link on the webpage (not sure if from the `#` or what)
- Fixed small grammatical error from `Alternatively is also possible` to `Alternatively it is also possible`
- Updated the shortcut name `MSYS2 MinGW x64` to `MSYS2 MINGW64`, since this is the default shortcut name that I'm seeing in Windows for current installs