### PR TITLE
Remove Google Plus sharing button for posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -20,7 +20,6 @@ layout: default
         Share &rarr;
         <a href="https://twitter.com/intent/tweet?text={{ page.title }}&url={{ site.url }}{{ page.url }}&via={{ site.twitter_username }}&related={{ site.twitter_username }}" rel="nofollow" target="_blank" title="Share on Twitter"><i class="fa fa-twitter"></i> Twitter</a>
         | <a href="https://facebook.com/sharer.php?u={{ site.url }}{{ page.url }}" rel="nofollow" target="_blank" title="Share on Facebook"><i class="fa fa-facebook"></i> Facebook</a>
-        | <a href="https://plus.google.com/share?url={{ site.url }}{{ page.url }}" rel="nofollow" target="_blank" title="Share on Google+"><i class="fa fa-google-plus"></i> Google+</a>
     </div>
 
     {% if site.disqus.shortname %}


### PR DESCRIPTION
Google Plus doesn't live anymore.