### PR TITLE
Fix typo on index.md code snippet

### DIFF
--- a/index.md
+++ b/index.md
@@ -16,9 +16,9 @@ public class MyActivityTest {
 
   @Test
   public void clickingButton_shouldChangeMessage() {
-    try (ActivityController<MyActvitiy> controller = Robolectric.buildActivity(MyActvitiy.class)) {
+    try (ActivityController<MyActivity> controller = Robolectric.buildActivity(MyActivity.class)) {
       controller.setup(); // Moves Activity to RESUMED state
-      MyActvitiy activity = controller.get();
+      MyActivity activity = controller.get();
 
       activity.findViewById(R.id.button).performClick();
       assertEquals(((TextView) activity.findViewById(R.id.text)).getText(), "Robolectric Rocks!");


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #190

## Summary
This PR fixes a typo on the [index.md code snippet](https://github.com/robolectric/robolectric.github.io/blob/master/index.md?plain=1#L19-L25), where it says `MyActvitiy` instead of `MyActivity`.