### PR TITLE
Remove reference to Robolectric Chrome extension

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,7 +11,6 @@
 
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
     <link href="/images/favicon.ico" rel="icon" type="image/ico" />
-    <link rel="chrome-webstore-item" href="https://chrome.google.com/webstore/detail/pjepcinimnfnaoopahdkpkefnefdkdgh">
 
     {% if jekyll.environment == 'production' and site.google_analytics %}
     {% include google-analytics.html %}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -78,22 +78,6 @@
             </ul>
         </section>
 
-        <section id="chrome-robolectric-extension-sidebar" class="hide-if-chrome-extension-is-installed">
-            <header class="major">
-                <h2>Chrome Extension</h2>
-            </header>
-            <article class="mini-post">
-                See Robolectric documentation inline with Android Developer Documentation.
-                <button onclick="chrome.webstore.install('https://chrome.google.com/webstore/detail/pjepcinimnfnaoopahdkpkefnefdkdgh')">Add to Chrome</button>
-            </article>
-        </section>
-        <script>
-            if (!window.chrome) {
-                var extSidebar = document.getElementById('chrome-robolectric-extension-sidebar');
-                extSidebar.parentNode.removeChild(extSidebar);
-            }
-        </script>
-
         <!-- Section -->
         <section>
             <header class="major">


### PR DESCRIPTION
The Robolectric Chrome extension is no longer supported, see https://github.com/robolectric/robolectric/discussions/7102.