### PR TITLE
Remove RoboGuice reference from "Customizing the Test Runner"

### DIFF
--- a/custom-test-runner.md
+++ b/custom-test-runner.md
@@ -17,51 +17,6 @@ Let's say you've defined a FooApplication in your manifest:
 ```xml
 <application android:name=".FooApplication">
 ```
-## RoboGuice
-
-If you're using RoboGuice, you would initialize the injector in your Application class:
-
-```java
-public class FooApplication extends Application {
-    @Override
-    public void onCreate() {
-        super.onCreate();
-
-        ApplicationModule module = new ApplicationModule();
-        setBaseApplicationInjector(this, DEFAULT_STAGE, newDefaultRoboModule(this), module);
-    }
-}
-```
-
-You can define a test version of the application named TestFooApplication:
-
-```java
-public class TestFooApplication extends FooApplication implements TestLifecycleApplication {
-    @Override
-    public void onCreate() {
-        super.onCreate();
-
-        TestApplicationModule module = new TestApplicationModule();
-        setBaseApplicationInjector(this, DEFAULT_STAGE, newDefaultRoboModule(this), module);
-    }
-
-    @Override
-    public void beforeTest(Method method) {
-    }
-
-    @Override
-    public void prepareTest(Object test) {
-        getInjector(this).injectMembers(test);
-    }
-
-    @Override
-    public void afterTest(Method method) {
-    }
-}
-```
-
-Robolectric will load the test version of the application which you can use to load a different set of bindings
-during tests.
 
 ## Hilt
 


### PR DESCRIPTION
RoboGuice is not maintained anymore, since August 2016.

Fixes #196