### PR TITLE
Unset 4.11 JavaDoc as latest version

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -73,7 +73,6 @@ menu:
         url: /javadoc/4.10/
       - title: "4.11"
         url: /javadoc/4.11/
-        class: italic
       - title: "4.12"
         url: /javadoc/4.12/
         class: italic


### PR DESCRIPTION
The 4.11 version still had the `italic` class, making it look like it's still the latest version, as well as version 4.12.