### PR TITLE
Remove 3.8 Javadoc

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -47,8 +47,6 @@ menu:
       url: /migrating
     - title: Javadoc
       items:
-      - title: "3.8"
-        url: /javadoc/3.8/
       - title: "4.0"
         url: /javadoc/4.0/
       - title: "4.1"


### PR DESCRIPTION
In #206, the Javadoc files for Robolectric 3.8 was removed. However, the link on the website was still available under the "Resources" section.