### PR TITLE
Update code blocks and javadoc URLs

### DIFF
--- a/_posts/2017-03-01-hermetic-builds.md
+++ b/_posts/2017-03-01-hermetic-builds.md
@@ -9,7 +9,7 @@ But what if you have a [hermetic build environment](http://blog.fahhem.com/2013/
 
 Here's a Gradle build script that'll help:
 
-```Groovy
+```groovy
 def robolectricVersion = '3.3'
 
 def androidSdkVersions = [

--- a/_posts/2018-05-09-robolectric-4-0-alpha.md
+++ b/_posts/2018-05-09-robolectric-4-0-alpha.md
@@ -42,7 +42,7 @@ In conjunction with Android Studio 3.2, Robolectric can now use resources proces
 
 To enable the use of toolchain-processed resources in Robolectric tests, make sure you're using Android Gradle Plugin version `com.android.tools.build:gradle:3.2.0-alpha14` or higher, and add the following to your `gradle.properties`:
 
-```groovy
+```properties
 android.enableUnitTestBinaryResources=true
 ```
 

--- a/_posts/2019-06-04-paused-looper.md
+++ b/_posts/2019-06-04-paused-looper.md
@@ -18,7 +18,7 @@ While in many cases this has no observable effect it can lead to bugs that are h
 Consider the code below. When run on the UI thread on a device, the assertion would pass.  
 
 
-```
+```java
 List<String> events = new ArrayList<>();
 events.add("before");
 new Handler(Looper.getMainLooper()).post(() -> events.add("after"));
@@ -61,13 +61,15 @@ background thread
 ## Using PAUSED LooperMode
 
 To switch to PAUSED:
+
 *   Use robolectric 4.3. In gradle add
 
-    ```
+    ```groovy
     dependencies {
       testImplementation 'org.robolectric:robolectric:4.3'
     }
     ```
+
 *   Apply the `LooperMode(PAUSED)` annotation to your test package/class/method
 *   Convert any background `org.robolectric.util.Scheduler` calls for controlling `Loopers` to 
 `shadowOf(looper)`
@@ -84,7 +86,7 @@ appropriate point to add a `shadowOf(getMainLooper()).idle()` call.
 
 Example:
 
-```
+```java
 import static android.os.Looper.getMainLooper;
 import static org.robolectric.annotation.LooperMode.Mode.PAUSED;
 import static org.robolectric.Shadows.shadowOf;

--- a/_posts/2023-11-11-improving-android-all-downloading.md
+++ b/_posts/2023-11-11-improving-android-all-downloading.md
@@ -24,7 +24,7 @@ and manually fetching the necessary android-all jars before running Robolectric 
 
 The first solution is setting a custom proxy for `MavenArtifactFetcher` like the following snippet:
 
-```Kotlin
+```kotlin
 testOptions {
     unitTests {
         includeAndroidResources = true
@@ -53,7 +53,7 @@ host and port for internally allowed proxy servers.
 most scenarios. For example, I often set the repository to a custom Chinese popular Maven mirror
 for my custom projects:
 
-```Kotlin
+```kotlin
 testOptions {
     unitTests {
         includeAndroidResources = true
@@ -76,7 +76,7 @@ Robolectric supports using android-all jars in a local directory with its offlin
 any android-all jars from the network when running Robolectric tests. We can follow the following
 snippet to enable Robolectric's offline mode for the project:
 
-```Kotlin
+```kotlin
 testOptions {
     unitTests {
         includeAndroidResources = true
@@ -99,7 +99,7 @@ I created a sample project to provide build scripts to download these
 android-all jars into this preinstrumented directory: 
 [robolectric-offline-sample](https://github.com/utzcoz/robolectric-offline-sample/).
 
-```Kotlin
+```kotlin
 plugins {
     `java-library`
 }

--- a/androidx_test.md
+++ b/androidx_test.md
@@ -16,7 +16,7 @@ test. Furthermore it will make your tests more portable and compatible with our 
 ### TestRunner
 
 It is now possible to use the AndroidX test runner in Robolectric tests. If you require a custom test runner currently,
-please check out the new [configuration and plugin API](http://robolectric.org/javadoc/4.2/org/robolectric/pluginapi/package-summary.html)
+please check out the new [configuration and plugin API](http://robolectric.org/javadoc/latest/org/robolectric/pluginapi/package-summary.html)
 and let us know if there are any extension points missing that you require.
 
 **Robolectric**

--- a/automated-migration.md
+++ b/automated-migration.md
@@ -31,7 +31,7 @@ The migration tool will make changes directly to source files in your codebase, 
             errorprone "com.google.errorprone:error_prone_core:2.3.2"
             errorproneJavac "com.google.errorprone:javac:9+181-r4173-1"
 
-            errorprone "org.robolectric:errorprone:{{ site.robolectric.version.preview | escape }}"
+            errorprone "org.robolectric:errorprone:{{ site.robolectric.version.current | escape }}"
         }
 
         afterEvaluate {

--- a/configuring.md
+++ b/configuring.md
@@ -10,7 +10,7 @@ Several aspects of Robolectric's behavior can be configured at runtime, using `r
 
 ### `@Config` Annotation
 
-To configure Robolectric for a single test class or method, use the <a href="/javadoc/latest/org/robolectric/annotation/Config.html">`@Config`</a> annotation. The annotation can be applied to classes and methods; values specified at the method level will override values specified at the class level.
+To configure Robolectric for a single test class or method, use the [`@Config`](/javadoc/latest/org/robolectric/annotation/Config.html) annotation. The annotation can be applied to classes and methods; values specified at the method level will override values specified at the class level.
 
 Base classes are also searched for annotations, so if you find yourself specifying the same values on a large number of tests, you can create a base class and move your `@Config` annotation to that class.
 

--- a/contributing.md
+++ b/contributing.md
@@ -56,7 +56,7 @@ Robolectric uses javadoc to document API's behavior. There are special rules for
 * All visible non-`@Implementation` methods SHOULD have descriptive Javadoc.
 * Don't write javadoc comments like "Shadow for (whatever).". The javadoc will appear in a section clearly related to testing, so make it make sense in context.
 
-Robolectric will release javadoc at robolectric.org after every main version released. For example, Robolectric's 4.7 javadoc is released at http://robolectric.org/javadoc/4.7/.
+Robolectric will release javadoc at robolectric.org after every main version released. For example, Robolectric's {{ site.robolectric.version.current | escape }} javadoc is released at http://robolectric.org/javadoc/{{ site.robolectric.version.current | escape }}/.
 
 ### Deprecations and Backwards Compatibility
 


### PR DESCRIPTION
This PR addresses the following points:
- Some code blocks in the documentation were using the wrong language or the language was not set at all.
- Some Javadoc were pointing at older version of Robolectric, instead of the latest version.
- Some pages displayed the wrong version of Robolectric (either an old version, or the snapshot version).