### PR TITLE
Use relative links to access Javadoc

### DIFF
--- a/_posts/2019-06-04-paused-looper.md
+++ b/_posts/2019-06-04-paused-looper.md
@@ -46,7 +46,7 @@ PAUSED mode vs the existing ‘LEGACY’ mode include:
 
 
 *   Tasks posted to the main looper are not automatically executed inline. Similar to the
-[ legacy paused IdleState](http://robolectric.org/javadoc/4.3/org/robolectric/util/Scheduler.IdleState.html#PAUSED), 
+[ legacy paused IdleState](/javadoc/4.3/org/robolectric/util/Scheduler.IdleState.html#PAUSED), 
 tasks posted to the main looper must be explicitly executed via `ShadowLooper` APIs. However, 
 we’ve made a couple additional improvements in PAUSED mode that make this easier:
 *   Robolectric will warn users if a test fails with unexecuted tasks in the main looper queue. 

--- a/androidx_test.md
+++ b/androidx_test.md
@@ -16,7 +16,7 @@ test. Furthermore it will make your tests more portable and compatible with our 
 ### TestRunner
 
 It is now possible to use the AndroidX test runner in Robolectric tests. If you require a custom test runner currently,
-please check out the new [configuration and plugin API](http://robolectric.org/javadoc/latest/org/robolectric/pluginapi/package-summary.html)
+please check out the new [configuration and plugin API](/javadoc/latest/org/robolectric/pluginapi/package-summary.html)
 and let us know if there are any extension points missing that you require.
 
 **Robolectric**

--- a/device-configuration.md
+++ b/device-configuration.md
@@ -81,7 +81,7 @@ public void testOrientationChange() {
 
 The string parameter to `setQualifiers()` has the same rules as `Config.qualifiers`.
 
-Note that `RuntimeEnvironment.setQualifiers()` updates the system and application resources with the new configuration, but does not trigger any action on extant activities or other components. [`ActivityController.configurationChange()`](http://robolectric.org/javadoc/latest/org/robolectric/android/controller/ActivityController.html#configurationChange-android.content.res.Configuration-) can be used to simulate the sequence of events that take place on a device when its configuration changes.
+Note that `RuntimeEnvironment.setQualifiers()` updates the system and application resources with the new configuration, but does not trigger any action on extant activities or other components. [`ActivityController.configurationChange()`](/javadoc/latest/org/robolectric/android/controller/ActivityController.html#configurationChange-android.content.res.Configuration-) can be used to simulate the sequence of events that take place on a device when its configuration changes.
 
 If the activity is configured to handle the configuration changes, `ActivityController.configurationChange()` will call the activity’s `onConfigurationChanged()` method. If not, `ActivityController` destroys and recreates the activity.
 


### PR DESCRIPTION
As requested in https://github.com/robolectric/robolectric.github.io/pull/212#discussion_r1580491625, I've extracted the changes that turn the links to the Javadoc into relative links in a dedicated PR.