### PR TITLE
Add link to GitHub to documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ site_url: "https://robolectric.org"
 copyright: "©2010-2024. All rights reserved."
 repo_url: "https://github.com/robolectric/robolectric"
 repo_name: Robolectric
+edit_uri: https://github.com/robolectric/robolectric.github.io/tree/master/docs
 
 theme:
   name: material
@@ -33,7 +34,9 @@ theme:
         icon: material/weather-sunny
         name: "Switch to light mode"
   features:
+    - content.action.view
     - content.code.copy
+    - content.tooltips
     - navigation.indexes
     - navigation.sections
     - navigation.tabs


### PR DESCRIPTION
This PR adds an icon to access the current documentation page directly on GitHub. This allows visitors to easily edit the Markdown file to submit a PR, if they have some improvement to suggest.
It also enables the tooltip plugin, to provide a more visual and reactive tooltip (see screenshot).

<img width="766" alt="Screenshot 2024-05-22 at 22 00 29" src="https://github.com/robolectric/robolectric.github.io/assets/1009664/9ea07712-fc91-424d-a94d-69c32867d2f8">
