### PR TITLE
Fix multiline Git command in `publish-javadoc.yml`

### DIFF
--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -97,7 +97,7 @@ jobs:
           git commit -m "Publish javadoc for Robolectric ${{ steps.robolectric_version.outputs.patchVersion }}" \
             -m "- Add javadoc for Robolectric ${{ steps.robolectric_version.outputs.patchVersion }}." \
             -m "- Update mkdocs.yml to add a navigation entry to the new javadoc." \
-            -m "- Update mkdocs.yml to use version ${{ steps.robolectric_version.outputs.patchVersion }}."
+            -m "- Update mkdocs.yml to use version ${{ steps.robolectric_version.outputs.patchVersion }}." \
             -m "Fixes #${{ github.event.issue.id }}"
           git push --set-upstream origin publish-javadoc-robolectric-${{ steps.robolectric_version.outputs.patchVersion }}
           gh pr create --fill


### PR DESCRIPTION
One of the line was missing the final `\`, so bash was treating the next line as a new command.

We're reach the PR creation part, so we are close to a fully functional workflow now 🙂 