### PR TITLE
Add missing GitHub token in `publish-javadoc.yml`

### DIFF
--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -88,6 +88,8 @@ jobs:
 
       - name: Create Pull Request
         if: ${{ steps.robolectric_version.outputs.patchVersion }}
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           cd robolectric.github.io
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
The GitHub token to create the PR was missing.

In the previous build, the branch was successfully pushed (I've deleted it now), but the PR could not be created, because the `GH_TOKEN` environment variable was missing.