### PR TITLE
Publish a new javadoc for each version of Robolectric

### DIFF
--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -59,10 +59,10 @@ jobs:
           ./gradlew clean aggregateDocs
 
       - name: Move the new javadoc
-        if: ${{ steps.robolectric_version.outputs.minorVersion }}
+        if: ${{ steps.robolectric_version.outputs.patchVersion }}
         run: |
           cd robolectric.github.io
-          targetFolder="docs/javadoc/${{ steps.robolectric_version.outputs.minorVersion }}"
+          targetFolder="docs/javadoc/${{ steps.robolectric_version.outputs.patchVersion }}"
           if [ -e $targetFolder ]; then
             rm -r $targetFolder
           fi
@@ -70,21 +70,17 @@ jobs:
           mv ../robolectric/build/docs/javadoc $targetFolder
 
       - name: Update Robolectric version in mkdocs.yml
-        if: ${{ steps.robolectric_version.outputs.minorVersion }}
+        if: ${{ steps.robolectric_version.outputs.patchVersion }}
         run: |
           cd robolectric.github.io
-          sed -i 's/^      current: ".*"$/      current: "${{ steps.robolectric_version.outputs.minorVersion }}"/' mkdocs.yml
-          sed -i 's/^      current_patched: ".*"$/      current_patched: "${{ steps.robolectric_version.outputs.patchVersion }}"/' mkdocs.yml
-
-          if [ "${{ steps.robolectric_version.outputs.minorVersion }}" == "${{ steps.robolectric_version.outputs.patchVersion }}" ]; then
-            sed -i 's/^\(    - "Javadoc":\)$/\1\n      - "${{ steps.robolectric_version.outputs.minorVersion }}": \/javadoc\/${{ steps.robolectric_version.outputs.minorVersion }}\//' mkdocs.yml
-          fi
+          sed -i 's/^      current: ".*"$/      current: "${{ steps.robolectric_version.outputs.patchVersion }}"/' mkdocs.yml
+          sed -i 's/^\(    - "Javadoc":\)$/\1\n      - "${{ steps.robolectric_version.outputs.patchVersion }}": \/javadoc\/${{ steps.robolectric_version.outputs.patchVersion }}\//' mkdocs.yml
 
       - name: Update latest javadoc symbolic link
-        if: ${{ steps.robolectric_version.outputs.minorVersion }}
+        if: ${{ steps.robolectric_version.outputs.patchVersion }}
         run: |
           cd robolectric.github.io
-          ln -sfn ${{ steps.robolectric_version.outputs.minorVersion }} docs/javadoc/latest
+          ln -sfn ${{ steps.robolectric_version.outputs.patchVersion }} docs/javadoc/latest
 
       - name: Create Pull Request
         if: ${{ steps.robolectric_version.outputs.patchVersion }}
@@ -100,6 +96,6 @@ jobs:
             -m "- Add javadoc for Robolectric ${{ steps.robolectric_version.outputs.patchVersion }}." \
             -m "- Update mkdocs.yml to add a navigation entry to the new javadoc." \
             -m "- Update mkdocs.yml to use version ${{ steps.robolectric_version.outputs.patchVersion }}." \
-            -m "Fixes #${{ github.event.issue.id }}"
+            -m "Fixes #${{ github.event.issue.number }}"
           git push --set-upstream origin publish-javadoc-robolectric-${{ steps.robolectric_version.outputs.patchVersion }}
           gh pr create --fill

--- a/docs/automated-migration.md
+++ b/docs/automated-migration.md
@@ -29,7 +29,7 @@ The migration tool will make changes directly to source files in your codebase, 
             errorprone "com.google.errorprone:error_prone_core:2.3.2"
             errorproneJavac "com.google.errorprone:javac:9+181-r4173-1"
 
-            errorprone "org.robolectric:errorprone:{{ robolectric.version.current_patched }}"
+            errorprone "org.robolectric:errorprone:{{ robolectric.version.current }}"
         }
 
         afterEvaluate {

--- a/docs/blog/posts/2018-10-25-robolectric-4-0.md
+++ b/docs/blog/posts/2018-10-25-robolectric-4-0.md
@@ -58,7 +58,7 @@ android {
 }
 
 dependencies {
-  testImplementation 'org.robolectric:robolectric:{{ robolectric.version.current_patched }}'
+  testImplementation 'org.robolectric:robolectric:{{ robolectric.version.current }}'
 }
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,7 +19,7 @@ Start by adding the following to your module's `build.gradle`/`build.gradle.kts`
 
     dependencies {
       testImplementation 'junit:junit:4.13.2'
-      testImplementation 'org.robolectric:robolectric:{{ robolectric.version.current_patched }}'
+      testImplementation 'org.robolectric:robolectric:{{ robolectric.version.current }}'
     }
     ```
 
@@ -36,7 +36,7 @@ Start by adding the following to your module's `build.gradle`/`build.gradle.kts`
 
     dependencies {
       testImplementation("junit:junit:4.13.2")
-      testImplementation("org.robolectric:robolectric:{{ robolectric.version.current_patched }}")
+      testImplementation("org.robolectric:robolectric:{{ robolectric.version.current }}")
     }
     ```
 
@@ -90,7 +90,7 @@ maven_install(
     name = "maven",
     artifacts = [
         "com.google.truth:truth:1.1.3",
-        "org.robolectric:robolectric:{{ robolectric.version.current_patched }}",
+        "org.robolectric:robolectric:{{ robolectric.version.current }}",
     ],
     repositories = [
         "https://maven.google.com",
@@ -128,7 +128,7 @@ Start by adding the following to your module's `pom.xml` file:
 <dependency>
     <groupId>org.robolectric</groupId>
     <artifactId>robolectric</artifactId>
-    <version>{{ robolectric.version.current_patched }}</version>
+    <version>{{ robolectric.version.current }}</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,14 +83,13 @@ extra:
     property: "UA-19269905-2"
   robolectric:
     version:
-      current: "4.12"
-      current_patched: "4.12.2"
+      current: "4.12.2"
   social:
     - name: "GitHub Project"
       icon: fontawesome/brands/github
       link: "http://github.com/robolectric/robolectric"
     - name: "robolectric@googlegroups.com"
-      icon: fontawesome/regular/envelope 
+      icon: fontawesome/regular/envelope
       link: "http://groups.google.com/group/robolectric"
     - name: "@Robolectric"
       icon: fontawesome/brands/x-twitter
@@ -135,7 +134,7 @@ nav:
       - "4.1": /javadoc/4.1/
       - "4.0": /javadoc/4.0/
   - "Blog":
-      - blog/index.md
+    - blog/index.md
 
 exclude_docs: |
   /javadoc/*/legal/jquery*.md


### PR DESCRIPTION
This PR allows the creation of a new folder for each version of Robolectric.
It removes the `robolectric.version.current_patch` variable from MkDocs, since it no longer makes sense.
I've also fixed the issue number in the created PR description.