### PR TITLE
Create workflow to lint Markdown files

### DIFF
--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -1,0 +1,25 @@
+name: "Lint Markdown"
+
+on:
+  merge_group:
+  pull_request:
+  push:
+    branches: [ master ]
+
+jobs:
+  lint_project:
+    name: "Lint Markdown"
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Lint Markdown
+        uses: DavidAnson/markdownlint-cli2-action@v16
+        with:
+          config: ".markdownlint.jsonc"
+          globs: "docs/**/*.md"

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -22,4 +22,6 @@ jobs:
         uses: DavidAnson/markdownlint-cli2-action@v16
         with:
           config: ".markdownlint.jsonc"
-          globs: "docs/**/*.md"
+          globs: |
+            "docs/**/*.md"
+            "#docs/javadoc/**/*.md"

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -3,6 +3,7 @@
   "MD013": {
     "line_length": 120,
     "heading_line_length": 120,
-    "code_block_line_length": 120
+    "code_block_line_length": 120,
+    "tables": false
   }
 }

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,9 +1,12 @@
 // https://github.com/DavidAnson/markdownlint/blob/main/schema/.markdownlint.jsonc
 {
+  // Line length: https://github.com/DavidAnson/markdownlint/blob/main/doc/md013.md
   "MD013": {
     "line_length": 120,
     "heading_line_length": 120,
     "code_block_line_length": 120,
     "tables": false
-  }
+  },
+  // Code block style: https://github.com/DavidAnson/markdownlint/blob/main/doc/md046.md
+  "MD046": false
 }

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,8 @@
+// https://github.com/DavidAnson/markdownlint/blob/main/schema/.markdownlint.jsonc
+{
+  "MD013": {
+    "line_length": 120,
+    "heading_line_length": 120,
+    "code_block_line_length": 120
+  }
+}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository contains the source of the documentation that lives at [robolect
 
 Make sure that you are on the `master` branch, and that it is up to date before making any changes. This is the default branch, so Git should put you there automatically.
 
+### Build the documentation locally
+
 Before submitting a Pull Request, run the documentation locally to check that the content and layout are correct. The documentation is built using [MkDocs](https://www.mkdocs.org/).
 
 To do so, make sure that you have [Python 3+ installed](https://www.python.org/downloads/), and then install the required dependencies by running:
@@ -18,6 +20,16 @@ Then you can execute the following command to access the documentation locally a
 
 ```bash
 mkdocs serve --open
+```
+
+### Validate your Markdown files
+
+If you modified any Markdown file, we recommend using [`DavidAnson/markdownlint-cli2`](https://github.com/DavidAnson/markdownlint-cli2) to ensure that the formatting rules are respected.
+
+Once installed, you can run the command below to perform the check. Add the `--fix` option to fix issues that can be addressed automatically. The non-resolved issues will be printed in the console.
+
+```bash
+markdownlint-cli2 "docs/**/*.md" "#docs/javadoc/**/*.md" --config .markdownlint.jsonc
 ```
 
 Once your Pull Request is merged, the documentation will be automatically built and deployed by GitHub Actions.

--- a/docs/androidx_test.md
+++ b/docs/androidx_test.md
@@ -14,104 +14,104 @@ It is now possible to use the AndroidX test runner in Robolectric tests. If you 
 test runner, please check out the [configuration and plugin API][configuration-plugin-api], and let
 us know if there are any extension points missing that you require.
 
-**Robolectric**
+!!! snippet "Robolectric"
 
-=== "Java"
+    === "Java"
 
-    ```java
-    import org.robolectric.RobolectricTestRunner;
+        ```java
+        import org.robolectric.RobolectricTestRunner;
 
-    @RunWith(RobolectricTestRunner.class)
-    public class SandwichTest {
-    }
-    ```
+        @RunWith(RobolectricTestRunner.class)
+        public class SandwichTest {
+        }
+        ```
 
-=== "Kotlin"
+    === "Kotlin"
 
-    ```kotlin
-    import org.robolectric.RobolectricTestRunner
+        ```kotlin
+        import org.robolectric.RobolectricTestRunner
 
-    @RunWith(RobolectricTestRunner::class)
-    class SandwichTest
-    ```
+        @RunWith(RobolectricTestRunner::class)
+        class SandwichTest
+        ```
 
-**AndroidX Test**
+!!! snippet "AndroidX Test"
 
-=== "Java"
+    === "Java"
 
-    ```java
-    import androidx.test.ext.junit.runners.AndroidJUnit4;
+        ```java
+        import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-    @RunWith(AndroidJUnit4.class)
-    public class SandwichTest {
-    }
-    ```
+        @RunWith(AndroidJUnit4.class)
+        public class SandwichTest {
+        }
+        ```
 
-=== "Kotlin"
+    === "Kotlin"
 
-    ```kotlin
-    import androidx.test.ext.junit.runners.AndroidJUnit4
+        ```kotlin
+        import androidx.test.ext.junit.runners.AndroidJUnit4
 
-    @RunWith(AndroidJUnit4::class)
-    class SandwichTest
-    ```
+        @RunWith(AndroidJUnit4::class)
+        class SandwichTest
+        ```
 
 ## Application
 
 Since most Android code is centric around a [`Context`][context-documentation], getting hold of your
 application’s context is a typical task for most tests.
 
-**Robolectric**
+!!! snippet "Robolectric"
 
-=== "Java"
+    === "Java"
 
-    ```java
-    import org.robolectric.RuntimeEnvironment;
+        ```java
+        import org.robolectric.RuntimeEnvironment;
 
-    @Before
-    void setUp() {
-      ExampleApplication app = (ExampleApplication) RuntimeEnvironment.application;
-      app.setLocationProvider(mockLocationProvider);
-    }
-    ```
+        @Before
+        void setUp() {
+          ExampleApplication app = (ExampleApplication) RuntimeEnvironment.application;
+          app.setLocationProvider(mockLocationProvider);
+        }
+        ```
 
-=== "Kotlin"
+    === "Kotlin"
 
-    ```kotlin
-    import org.robolectric.RuntimeEnvironment
+        ```kotlin
+        import org.robolectric.RuntimeEnvironment
 
-    @Before
-    fun setUp() {
-      val app = RuntimeEnvironment.application as ExampleApplication
-      app.setLocationProvider(mockLocationProvider)
-    }
-    ```
+        @Before
+        fun setUp() {
+          val app = RuntimeEnvironment.application as ExampleApplication
+          app.setLocationProvider(mockLocationProvider)
+        }
+        ```
 
-**AndroidX Test**
+!!! snippet "AndroidX Test"
 
-=== "Java"
+    === "Java"
 
-    ```java
-    import androidx.test.core.app.ApplicationProvider;
+        ```java
+        import androidx.test.core.app.ApplicationProvider;
 
-    @Before
-    void setUp() {
-      ExampleApplication app = ApplicationProvider.getApplicationContext<ExampleApplication>();
-      app.setLocationProvider(mockLocationProvider);
-    }
-    ```
+        @Before
+        void setUp() {
+          ExampleApplication app = ApplicationProvider.getApplicationContext<ExampleApplication>();
+          app.setLocationProvider(mockLocationProvider);
+        }
+        ```
 
-=== "Kotlin"
+    === "Kotlin"
 
-    ```kotlin
-    import androidx.test.core.app.ApplicationProvider
+        ```kotlin
+        import androidx.test.core.app.ApplicationProvider
 
-    @Before
-    fun setUp() {
-      val app = ApplicationProvider.getApplicationContext<ExampleApplication>()
-      app.setLocationProvider(mockLocationProvider)
-    }
-    ```
+        @Before
+        fun setUp() {
+          val app = ApplicationProvider.getApplicationContext<ExampleApplication>()
+          app.setLocationProvider(mockLocationProvider)
+        }
+        ```
 
 ## Activities
 
@@ -131,94 +131,94 @@ places tighter restrictions around lifecycle transitions, namely that invalid or
 transitions are not possible. If you'd like a [`Rule`][junit-rule]-based equivalent please use
 [`ActivityScenarioRule`][activity-scenario-rule] instead.
 
-**Robolectric**
+!!! snippet "Robolectric"
 
-=== "Java"
+    === "Java"
 
-    ```java
-    import org.robolectric.Robolectric;
-    import org.robolectric.android.controller.ActivityController;
+        ```java
+        import org.robolectric.Robolectric;
+        import org.robolectric.android.controller.ActivityController;
 
-    public class LocationTrackerActivityTest {
-        @Test
-        public void locationListenerShouldBeUnregisteredInCreatedState() {
-            // GIVEN
-            ActivityController<LocationTrackerActivity> controller = Robolectric.buildActivity<LocationTrackerActivity>().setup();
-    
-            // WHEN
-            controller.pause().stop();
-    
-            // THEN
-            assertThat(controller.get().getLocationListener()).isNull();
-         }
-    }
-    ```
+        public class LocationTrackerActivityTest {
+            @Test
+            public void locationListenerShouldBeUnregisteredInCreatedState() {
+                // GIVEN
+                ActivityController<LocationTrackerActivity> controller = Robolectric.buildActivity<LocationTrackerActivity>().setup();
 
-=== "Kotlin"
+                // WHEN
+                controller.pause().stop();
 
-    ```kotlin
-    import org.robolectric.Robolectric
-
-    class LocationTrackerActivityTest {
-        @Test
-        fun locationListenerShouldBeUnregisteredInCreatedState() {
-            // GIVEN
-            val controller = Robolectric.buildActivity<LocationTrackerActivity>().setup()
-    
-            // WHEN
-            controller.pause().stop()
-    
-            // THEN
-            assertThat(controller.get().locationListener).isNull()
-         }
-    }
-    ```
-
-**Android X Test**
-
-=== "Java"
-
-    ```java
-    import androidx.lifecycle.Lifecycle;
-    import androidx.test.core.app.ActivityScenario;
-
-    public class LocationTrackerActivityTest {
-        @Test
-        public void locationListenerShouldBeUnregisteredInCreatedState() {
-            // GIVEN
-            ActivityScenario<LocationTrackerActivity> scenario = ActivityScenario.launchActivity<LocationTrackerActivity>();
-    
-            // WHEN
-            scenario.moveToState(Lifecycle.State.CREATED);
-    
-            // THEN
-            scenario.onActivity(activity -> assertThat(activity.getLocationListener()).isNull());
+                // THEN
+                assertThat(controller.get().getLocationListener()).isNull();
+             }
         }
-    }
-    ```
+        ```
 
-=== "Kotlin"
+    === "Kotlin"
 
-    ```kotlin
-    import androidx.lifecycle.Lifecycle
-    import androidx.test.core.app.ActivityScenario
+        ```kotlin
+        import org.robolectric.Robolectric
 
-    class LocationTrackerActivityTest {
-        @Test
-        fun locationListenerShouldBeUnregisteredInCreatedState() {
-            // GIVEN
-            val scenario = ActivityScenario.launchActivity<LocationTrackerActivity>()
-    
-            // WHEN
-            scenario.moveToState(Lifecycle.State.CREATED)
-    
-            // THEN
-            scenario.onActivity { activity ->
-                assertThat(activity.locationListener).isNull()
+        class LocationTrackerActivityTest {
+            @Test
+            fun locationListenerShouldBeUnregisteredInCreatedState() {
+                // GIVEN
+                val controller = Robolectric.buildActivity<LocationTrackerActivity>().setup()
+
+                // WHEN
+                controller.pause().stop()
+
+                // THEN
+                assertThat(controller.get().locationListener).isNull()
+             }
+        }
+        ```
+
+!!! snippet "AndroidX Test"
+
+    === "Java"
+
+        ```java
+        import androidx.lifecycle.Lifecycle;
+        import androidx.test.core.app.ActivityScenario;
+
+        public class LocationTrackerActivityTest {
+            @Test
+            public void locationListenerShouldBeUnregisteredInCreatedState() {
+                // GIVEN
+                ActivityScenario<LocationTrackerActivity> scenario = ActivityScenario.launchActivity<LocationTrackerActivity>();
+
+                // WHEN
+                scenario.moveToState(Lifecycle.State.CREATED);
+
+                // THEN
+                scenario.onActivity(activity -> assertThat(activity.getLocationListener()).isNull());
             }
         }
-    }
-    ```
+        ```
+
+    === "Kotlin"
+
+        ```kotlin
+        import androidx.lifecycle.Lifecycle
+        import androidx.test.core.app.ActivityScenario
+
+        class LocationTrackerActivityTest {
+            @Test
+            fun locationListenerShouldBeUnregisteredInCreatedState() {
+                // GIVEN
+                val scenario = ActivityScenario.launchActivity<LocationTrackerActivity>()
+
+                // WHEN
+                scenario.moveToState(Lifecycle.State.CREATED)
+
+                // THEN
+                scenario.onActivity { activity ->
+                    assertThat(activity.locationListener).isNull()
+                }
+            }
+        }
+        ```
 
 Note that in Robolectric since both the test and UI event loop run on the same thread,
 synchronization is not an issue. [`ActivityScenario.onActivity`][activity-scenario-on-activity]

--- a/docs/automated-migration.md
+++ b/docs/automated-migration.md
@@ -4,6 +4,8 @@ hide:
 - toc
 ---
 
+<!-- markdownlint-disable MD029 -->
+
 # Automated Migration
 
 Robolectric provides an automated migration tool to help keep your test suite up to date with
@@ -78,7 +80,6 @@ and commit to your source control system.
     ```
 
 4. Make sure your code still compiles and commit changes.
-
 5. Update your project to the new version of Robolectric.
 
 The migration tool will make a best effort attempt to adjust the source code, but there might be

--- a/docs/blog/posts/2018-10-25-robolectric-4-0.md
+++ b/docs/blog/posts/2018-10-25-robolectric-4-0.md
@@ -7,6 +7,7 @@ authors:
 slug: robolectric-4-0
 ---
 
+<!-- markdownlint-disable-next-line MD026 -->
 # Robolectric 4.0 Released!
 
 Robolectric 4.0 is released! Here's what's new!

--- a/docs/blog/posts/2021-10-06-sharedTest.md
+++ b/docs/blog/posts/2021-10-06-sharedTest.md
@@ -5,6 +5,8 @@ authors:
 slug: sharedTest
 ---
 
+<!-- markdownlint-disable MD052 -->
+
 # `sharedTest` pattern: sharing tests and speeding up development
 
 After [Robolectric's 4.0 release][2], Robolectric supports the [`AndroidJUnit4` test runner][3],
@@ -142,21 +144,22 @@ There are some Google's projects have used `sharedTest` pattern to sharing test 
 
 - [accompanist: [All] Share tests to run on Robolectric & Emulators by chrisbanes][10]
 
+<!-- markdownlint-disable MD013 -->
 [1]: https://medium.com/androiddevelopers/write-once-run-everywhere-tests-on-android-88adb2ba20c5 "Write Once, Run Everywhere Tests on Android"
 [2]: {{ config.site_url }}blog/2018/10/25/robolectric-4-0/ "Robolectric 4.0 release"
-[3]: https://developer.android.com/training/testing/junit-runner "AndroidJUnit4 test runner"
-[4]: https://developer.android.com/training/testing/espresso/ "Espresso"
-[5]: https://developer.android.com/reference/androidx/test/core/app/ActivityScenario "ActivityScenario"
-[6]: https://proandroiddev.com/sharing-code-between-local-and-instrumentation-tests-c0b57ebd3200 "Sharing code between local and instrumentation tests by Alex Zhukovich"
-[7]: https://medium.com/wirex/powerful-approaches-to-develop-shared-android-tests-15c508e3ce8a "Powerful Approaches to Develop Shared Android Tests by Oleksandr Hrybuk"
-[8]: https://blog.danlew.net/2015/11/02/sharing-code-between-unit-tests-and-instrumentation-tests-on-android/ "Sharing code between unit tests and instrumentation tests on Android by Dan Lew"
-[9]: https://github.com/robolectric/robolectric/pull/6570 "Add ctesque common tests to android test"
-[10]: https://github.com/google/accompanist/pull/180 "[All] Share tests to run on Robolectric & Emulators by chrisbanes"
-[11]: https://github.com/android/testing-samples/blob/main/ui/espresso/FragmentScenarioSample/app/build.gradle "FragmentScenarioSample of androidx.test with sharedTest pattern"
-[12]: https://www.raywenderlich.com/books/android-test-driven-development-by-tutorials/ "Android Test-Driven Development by Tutorials, by Fernando Sproviero, Victoria Gonda and Lance Gleason, Razeware LLC (July 20, 2021)"
-[13]: https://github.com/android/android-test "androidx.test"
-[14]: https://github.com/android/testing-samples/blob/main/ui/espresso/FragmentScenarioSample/app/src/sharedTest/java/com/example/android/testing/espresso/fragmentscenario/SampleFragmentTest.kt "SampleFragmentTest.kt of FragmentScenarioSample"
-[15]: https://github.com/android/testing-samples/tree/main/ui/espresso/FragmentScenarioSample "FragmentScenarioSample of testing-samples"
-[16]: https://github.com/android/testing-samples/tree/main/ui/espresso/FragmentScenarioSample/app/src/sharedTest "sharedTest directory of FragmentScenarioSample"
-[17]: https://cs.android.com/androidx/android-test/+/master:ext/junit/java/androidx/test/ext/junit/runners/AndroidJUnit4.java "AndroidJUnit4 source code"
-[18]: https://developer.android.com/training/testing/fundamentals#create-test-iteratively "TDD cycles"
+[3]: <https://developer.android.com/training/testing/junit-runner> "AndroidJUnit4 test runner"
+[4]: <https://developer.android.com/training/testing/espresso/> "Espresso"
+[5]: <https://developer.android.com/reference/androidx/test/core/app/ActivityScenario> "ActivityScenario"
+[6]: <https://proandroiddev.com/sharing-code-between-local-and-instrumentation-tests-c0b57ebd3200> "Sharing code between local and instrumentation tests by Alex Zhukovich"
+[7]: <https://medium.com/wirex/powerful-approaches-to-develop-shared-android-tests-15c508e3ce8a> "Powerful Approaches to Develop Shared Android Tests by Oleksandr Hrybuk"
+[8]: <https://blog.danlew.net/2015/11/02/sharing-code-between-unit-tests-and-instrumentation-tests-on-android/> "Sharing code between unit tests and instrumentation tests on Android by Dan Lew"
+[9]: <https://github.com/robolectric/robolectric/pull/6570> "Add ctesque common tests to android test"
+[10]: <https://github.com/google/accompanist/pull/180> "[All] Share tests to run on Robolectric & Emulators by chrisbanes"
+[11]: <https://github.com/android/testing-samples/blob/main/ui/espresso/FragmentScenarioSample/app/build.gradle> "FragmentScenarioSample of androidx.test with sharedTest pattern"
+[12]: <https://www.raywenderlich.com/books/android-test-driven-development-by-tutorials/> "Android Test-Driven Development by Tutorials, by Fernando Sproviero, Victoria Gonda and Lance Gleason, Razeware LLC (July 20, 2021)"
+[13]: <https://github.com/android/android-test> "androidx.test"
+[14]: <https://github.com/android/testing-samples/blob/main/ui/espresso/FragmentScenarioSample/app/src/sharedTest/java/com/example/android/testing/espresso/fragmentscenario/SampleFragmentTest.kt> "SampleFragmentTest.kt of FragmentScenarioSample"
+[15]: <https://github.com/android/testing-samples/tree/main/ui/espresso/FragmentScenarioSample> "FragmentScenarioSample of testing-samples"
+[16]: <https://github.com/android/testing-samples/tree/main/ui/espresso/FragmentScenarioSample/app/src/sharedTest> "sharedTest directory of FragmentScenarioSample"
+[17]: <https://cs.android.com/androidx/android-test/+/master:ext/junit/java/androidx/test/ext/junit/runners/AndroidJUnit4.java> "AndroidJUnit4 source code"
+[18]: <https://developer.android.com/training/testing/fundamentals#create-test-iteratively> "TDD cycles"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,1 +1,2 @@
+<!-- markdownlint-disable-next-line MD034 MD041 -->
 --8<-- "https://raw.githubusercontent.com/robolectric/robolectric/master/.github/CONTRIBUTING.md"

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -17,13 +17,13 @@ shadow object to associate with it.
 Using byte code instrumentation, Robolectric is able to weave in cross-platform fake implementations
 to substitute for native code and add additional APIs to make testing possible.
 
-### What's in a Name?
+## What's in a Name?
 
 Why "Shadow"? Shadow objects are not quite [Proxies][proxy-pattern], not quite [Fakes][fake-object],
 not quite [Mocks or Stubs][mocks-arent-stubs]. Shadows are sometimes hidden, sometimes seen, and can
 lead you to the real object. At least we didn't call them "sheep", which we were considering.
 
-### Shadow Classes
+## Shadow Classes
 
 Shadow classes always need a public no-arg constructor so that the Robolectric framework can
 instantiate them. They are associated to the class that they Shadow with an
@@ -48,7 +48,7 @@ Shadow class should extend `ViewGroup`'s superclass' Shadow, `ShadowView`.
     class ShadowViewGroup : ShadowView
     ```
 
-### Methods
+## Methods
 
 Shadow objects implement methods that have the same signature as the corresponding Android class.
 Robolectric will invoke the method on a Shadow object when a method with the same signature on the
@@ -112,7 +112,7 @@ which they were originally defined. Otherwise, Robolectric's lookup mechanism wi
 method is defined on `ShadowViewGroup` instead of `ShadowView` then it will not be found at run time
 even when `setEnabled()` is called on an instance of `ViewGroup`.
 
-### Shadowing Constructors
+## Shadowing Constructors
 
 Once a Shadow object is instantiated, Robolectric will look for a method named  `__constructor__`
 and annotated with `@Implementation` which has the same arguments as the constructor that was
@@ -157,7 +157,7 @@ Robolectric would invoke the following  `__constructor__` method that receives a
       }
     ```
 
-### Getting access to the real instance
+## Getting access to the real instance
 
 Sometimes Shadow classes may want to refer to the object they are shadowing, e.g., to manipulate
 fields. A Shadow class can achieve this by declaring a field annotated with
@@ -276,7 +276,7 @@ Note, by default `Shadows.shadowOf()` method will not work with custom shadows. 
 use [`Shadow.extract()`][shadow-extract] and cast the return value to the custom Shadow class you
 implemented.
 
-### Building a library of Custom Shadows.
+### Building a library of Custom Shadows
 
 If you find yourself building a library of custom shadows, you should consider running Robolectric's
 shadow annotation processor on your library of shadows. This provides a number of benefits such as:
@@ -366,6 +366,7 @@ and reduce the bloat in your own codebase.
 [fake-object]: https://c2.com/cgi/wiki?FakeObject "Fake Object"
 [implementation-documentation]: javadoc/latest/org/robolectric/annotation/Implementation.html
 [implements-documentation]: javadoc/latest/org/robolectric/annotation/Implements.html
+<!-- markdownlint-disable-next-line MD053 -->
 [kapt-documentation]: https://kotlinlang.org/docs/kapt.html
 [mockito]: https://site.mockito.org/
 [mocks-arent-stubs]: https://martinfowler.com/articles/mocksArentStubs.html#TheDifferenceBetweenMocksAndStubs "Mocks Aren't Stubs"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -208,7 +208,7 @@ If you are not sure if resources are being loaded for a particular library, enab
 setting the system property `robolectric.logging.enabled = true` and run your tests. You should see
 lots of output like:
 
-```
+```text
 Loading resources for 'com.foo' from build/unpacked-libraries/library1...
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,8 @@ hide:
 - toc
 ---
 
+<!-- markdownlint-disable MD033 MD041 -->
+
 <div align="center">
   <img src="images/robolectric-horizontal.png" alt="{{ config.site_name }}" />
 
@@ -55,7 +57,7 @@ Tests run inside the JVM in seconds. With Robolectric you can write tests like t
 
 <div class="grid cards" markdown>
 
--   **Test APIs & Isolation**
+- **Test APIs & Isolation**
 
     ---
 
@@ -71,7 +73,7 @@ Tests run inside the JVM in seconds. With Robolectric you can write tests like t
     Robolectric provides a [test double][test-double] that's suitable for most unit testing
     scenarios.
 
--   **No Mocking Frameworks Required**
+- **No Mocking Frameworks Required**
 
     ---
 
@@ -84,7 +86,7 @@ Tests run inside the JVM in seconds. With Robolectric you can write tests like t
     instead of the implementation of Android. You can still use a mocking framework along with
     Robolectric if you like.
 
--   **Run Tests Outside the Emulator**
+- **Run Tests Outside the Emulator**
 
     ---
 
@@ -93,7 +95,7 @@ Tests run inside the JVM in seconds. With Robolectric you can write tests like t
     installing steps aren't necessary, reducing test cycles from minutes to seconds so you can
     iterate quickly and refactor your code with confidence.
 
--   **SDK, Resources, & Native Method Simulation**
+- **SDK, Resources, & Native Method Simulation**
 
     ---
 

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -100,14 +100,18 @@ code, you may need to fix your tests.
 
 Some likely issues include:
 
-* `android.view.InflateException: Binary XML file line #3: Failed to resolve attribute at index 17:
-  TypedValue{t=0x2/d=0x7f01000e a=-1}`<br/>
-  This happens when your [`Activity`][activity-documentation] is using a theme that lacks values for
-  certain attributes used by layouts. Make sure you've specified an appropriate theme for your
-  activities in your `AndroidManifest`.
+!!! quote ""
+
+    > android.view.InflateException: Binary XML file line #3: Failed to resolve attribute at index
+    > 17: TypedValue{t=0x2/d=0x7f01000e a=-1}
+
+    This happens when your [`Activity`][activity-documentation] is using a theme that lacks values
+    for certain attributes used by layouts. Make sure you've specified an appropriate theme for your
+    activities in your `AndroidManifest`.
 
 ---
 
+<!-- markdownlint-disable-next-line MD033 -->
 ## Migrating to 3.6<a name="migrating-from-35-to-36"></a>
 
 Previously, Robolectric's [`Display`][display-documentation] and
@@ -123,6 +127,7 @@ modified for new dimensions, or by pinning them to the old size:
 
 ---
 
+<!-- markdownlint-disable-next-line MD033 -->
 ## Migrating to 3.4<a name="migrating-from-33-to-34"></a>
 
 ### Dependencies
@@ -139,7 +144,7 @@ Shadow pattern as with other framework classes. You can use
 | 3.3 (was `@Deprecated`)                                 | 3.4                                                            |
 |---------------------------------------------------------|----------------------------------------------------------------|
 | `org.robolectric.res.builder.RobolectricPackageManager` | [`ShadowPackageManager`][shadow-package-manager-javadoc]       |
-| `RuntimeEnvironment.getRobolectricPackageManager()   `  | `shadowOf(RuntimeEnvironment.application.getPackageManager())` |
+| `RuntimeEnvironment.getRobolectricPackageManager()`     | `shadowOf(RuntimeEnvironment.application.getPackageManager())` |
 
 If you were using `RuntimeEnvironment.setRobolectricPackageManager()` to install a custom
 `PackageManager`, you should move your custom behavior to a subclass of
@@ -162,6 +167,7 @@ The deprecated and redundant `attach()` method has been removed from
 
 ---
 
+<!-- markdownlint-disable-next-line MD033 -->
 ## Migrating to 3.3<a name="migrating-from-32-to-33"></a>
 
 ### Moved classes
@@ -219,13 +225,14 @@ that we've implemented quite a bit more of `PackageManager`, so you might not ne
 any longer.
 
 Starting with 3.4, `DefaultPackageManager` will be removed and its functionality will be moved into
-`ShadowApplicationPackageManager`.
+`ShadowApplicationPackageManager`. In general, we recommand using Android Framework APIs where
+possible.
 
-| 3.2 (now `@Deprecated`)                                                              | 3.3                                                                                                                  |
-|--------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
-| `RobolectricPackageManager rpm = RuntimeEnvironment.getRobolectricPackageManager();` | `ShadowPackageManager shadowPackageManager`<br/>`  = shadowOf(context.getPackageManager());`                         |
-| `PackageManager packageManager = RuntimeEnvironment.getPackageManager();`            | `// Prefer Android Framework APIs where possible`<br/>`PackageManager packageManager = context.getPackageManager();` |
-| `RuntimeEnvironment.setRobolectricPackageManager(customPackageManager);`             | Use a custom shadow instead! See below.                                                                              |
+| 3.2 (now `@Deprecated`)                                                              | 3.3                                                                                  |
+|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| `RobolectricPackageManager rpm = RuntimeEnvironment.getRobolectricPackageManager();` | `ShadowPackageManager shadowPackageManager = shadowOf(context.getPackageManager());` |
+| `PackageManager packageManager = RuntimeEnvironment.getPackageManager();`            | `PackageManager packageManager = context.getPackageManager();`                       |
+| `RuntimeEnvironment.setRobolectricPackageManager(customPackageManager);`             | Use a custom shadow instead! See below.                                              |
 
 Replace subclasses of `DefaultPackageManager` by a custom shadow (and be a good citizen by
 contributing your enhancements upstream 🙂):
@@ -276,6 +283,7 @@ more [here](getting-started.md).
 
 ---
 
+<!-- markdownlint-disable-next-line MD033 -->
 ## Migrating to 3.2<a name="migrating-from-31-to-32"></a>
 
 ### Programmatic Configuration
@@ -347,6 +355,7 @@ configure all tests, the expected location of the file has been changed.
 
 ---
 
+<!-- markdownlint-disable-next-line MD033 -->
 ## Migrating to 3.1<a name="migrating-from-30-to-31"></a>
 
 ### Changes
@@ -411,6 +420,7 @@ configure all tests, the expected location of the file has been changed.
 
 ---
 
+<!-- markdownlint-disable-next-line MD033 -->
 ## Migrating to 3.0<a name="migrating-from-24-to-30"></a>
 
 ### New Features
@@ -435,29 +445,29 @@ configure all tests, the expected location of the file has been changed.
 
 ### Major Changes
 
-| 2.4                                                                                            | 3.0                                                                                                                                                                                 |
-|------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `Robolectric.application`                                                                      | `RuntimeEnvironment.application`                                                                                                                                                    |
-| `Robolectric.shadowOf`                                                                         | `Shadows.shadowOf`                                                                                                                                                                  |
-| `Robolectric.Reflection.setFinalStaticField`                                                   | `ReflectionHelpers.setStaticField`                                                                                                                                                  |
-| `org.robolectric.Robolectric.<xxx>Looper`                                                      | `org.robolectric.shadows.ShadowLooper.<xxx>Looper`                                                                                                                                  |
-| `org.robolectric.Robolectric.getBackgroundScheduler`                                           | `org.robolectric.Robolectric.getBackgroundThreadScheduler`                                                                                                                          |
-| `org.robolectric.Robolectric.runBackgroundTasks`                                               | `org.robolectric.Robolectric.getBackgroundThreadScheduler().advanceBy(0)` (also `org.robolectric.Robolectric.flushBackgroundThreadScheduler` will run delayed background tasks too) |
-| `org.robolectric.Robolectric.getUiThreadScheduler`                                             | `org.robolectric.Robolectric.getForegroundThreadScheduler`                                                                                                                          |
-| `org.robolectric.Robolectric.runUiThreadTasks`                                                 | `org.robolectric.shadows.ShadowLooper.runUiThreadTasks`                                                                                                                             |
-| `org.robolectric.Robolectric.runUiThreadTasksIncludingDelayedTasks`                            | `org.robolectric.shadows.ShadowLooper.runUiThreadTasksIncludingDelayedTasks`<br>or<br>`org.robolectric.Robolectric.flushForegroundThreadScheduler`                                  |
-| `org.robolectric.Robolectric.getShadowApplication`                                             | `org.robolectric.shadows.ShadowApplication.getInstance`                                                                                                                             |
-| `FragmentTestUtil.startFragment`(v4/v11)                                                       | `SupportFragmentTestUtil.startFragment` (v4)<br>`FragmentTestUtil.startFragment` (v11)                                                                                              |
-| `org.robolectric.tester.android.view.TestMenuItem`                                             | `org.robolectric.fakes.RoboMenuItem`                                                                                                                                                |
-| `ActivityController.of`                                                                        | `Robolectric.buildActivity`                                                                                                                                                         |
-| `org.robolectric.Config.properties`                                                            | `robolectric.properties`                                                                                                                                                            |
-| `@Config(emulateSdk=...)` / `@Config(reportSdk=...)`                                           | `@Config(sdk=...)`                                                                                                                                                                  |
-| `org.robolectric.shadows.ShadowHandler`                                                        | `org.robolectric.shadows.ShadowLooper`                                                                                                                                              |
-| `org.robolectric.shadows.ShadowSettings.SettingsImpl`                                          | `org.robolectric.shadows.ShadowSettings.ShadowSystem`                                                                                                                               |
-| `Robolectric.packageManager = instance`                                                        | `RuntimeEnvironment.setRobolectricPackageManager(instance)`                                                                                                                         |
-| `org.robolectric.res.builder.RobolectricPackageManager`<br>changed from `class` to `interface` | `org.robolectric.res.builder.DefaultPackageManager`                                                                                                                                 |
-| `org.robolectric.shadows.ShadowMenuInflater`                                                   | ?                                                                                                                                                                                   |
-| `org.robolectric.Robolectric.clickOn`                                                          | `org.robolectric.shadows.ShadowView.clickOn`                                                                                                                                        |
+| 2.4                                                                                         | 3.0                                                                                                                                                                                 |
+|---------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Robolectric.application`                                                                   | `RuntimeEnvironment.application`                                                                                                                                                    |
+| `Robolectric.shadowOf`                                                                      | `Shadows.shadowOf`                                                                                                                                                                  |
+| `Robolectric.Reflection.setFinalStaticField`                                                | `ReflectionHelpers.setStaticField`                                                                                                                                                  |
+| `org.robolectric.Robolectric.<xxx>Looper`                                                   | `org.robolectric.shadows.ShadowLooper.<xxx>Looper`                                                                                                                                  |
+| `org.robolectric.Robolectric.getBackgroundScheduler`                                        | `org.robolectric.Robolectric.getBackgroundThreadScheduler`                                                                                                                          |
+| `org.robolectric.Robolectric.runBackgroundTasks`                                            | `org.robolectric.Robolectric.getBackgroundThreadScheduler().advanceBy(0)` (also `org.robolectric.Robolectric.flushBackgroundThreadScheduler` will run delayed background tasks too) |
+| `org.robolectric.Robolectric.getUiThreadScheduler`                                          | `org.robolectric.Robolectric.getForegroundThreadScheduler`                                                                                                                          |
+| `org.robolectric.Robolectric.runUiThreadTasks`                                              | `org.robolectric.shadows.ShadowLooper.runUiThreadTasks`                                                                                                                             |
+| `org.robolectric.Robolectric.runUiThreadTasksIncludingDelayedTasks`                         | `org.robolectric.shadows.ShadowLooper.runUiThreadTasksIncludingDelayedTasks` or `org.robolectric.Robolectric.flushForegroundThreadScheduler`                                        |
+| `org.robolectric.Robolectric.getShadowApplication`                                          | `org.robolectric.shadows.ShadowApplication.getInstance`                                                                                                                             |
+| `FragmentTestUtil.startFragment`(v4/v11)                                                    | `SupportFragmentTestUtil.startFragment` (v4) / `FragmentTestUtil.startFragment` (v11)                                                                                               |
+| `org.robolectric.tester.android.view.TestMenuItem`                                          | `org.robolectric.fakes.RoboMenuItem`                                                                                                                                                |
+| `ActivityController.of`                                                                     | `Robolectric.buildActivity`                                                                                                                                                         |
+| `org.robolectric.Config.properties`                                                         | `robolectric.properties`                                                                                                                                                            |
+| `@Config(emulateSdk=...)` / `@Config(reportSdk=...)`                                        | `@Config(sdk=...)`                                                                                                                                                                  |
+| `org.robolectric.shadows.ShadowHandler`                                                     | `org.robolectric.shadows.ShadowLooper`                                                                                                                                              |
+| `org.robolectric.shadows.ShadowSettings.SettingsImpl`                                       | `org.robolectric.shadows.ShadowSettings.ShadowSystem`                                                                                                                               |
+| `Robolectric.packageManager = instance`                                                     | `RuntimeEnvironment.setRobolectricPackageManager(instance)`                                                                                                                         |
+| `org.robolectric.res.builder.RobolectricPackageManager` changed from `class` to `interface` | `org.robolectric.res.builder.DefaultPackageManager`                                                                                                                                 |
+| `org.robolectric.shadows.ShadowMenuInflater`                                                | ?                                                                                                                                                                                   |
+| `org.robolectric.Robolectric.clickOn`                                                       | `org.robolectric.shadows.ShadowView.clickOn`                                                                                                                                        |
 
 * `Robolectric.shadowOf_` has been removed. Similar functionality exists in
   `ShadowExtractor.extract`.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -17,3 +17,19 @@
 .md-typeset .grid {
     grid-template-columns: repeat(auto-fit, minmax(24rem, 1fr))
 }
+
+/* Create a "snippet" admonition type */
+.md-typeset .admonition.snippet,
+.md-typeset details.snippet {
+  border-color: rgb(158, 158, 158);
+}
+.md-typeset .snippet > .admonition-title,
+.md-typeset .snippet > summary {
+  background-color: rgba(158, 158, 158, 0.1);
+}
+.md-typeset .snippet > .admonition-title::before,
+.md-typeset .snippet > summary::before {
+  background-color: rgb(158, 158, 158);
+  -webkit-mask-image: var(--md-admonition-icon--example);
+          mask-image: var(--md-admonition-icon--example);
+}

--- a/docs/using-add-on-modules.md
+++ b/docs/using-add-on-modules.md
@@ -6,6 +6,7 @@ the base Android SDK are provided by the main Robolectric module. Additional sha
 dedicated packages.
 
 > [!NOTE]
+>
 > - [Robolectric 3.4][robolectric-3.4-release] doesn't include the `shadows-` prefix in the package
     name (i.e., `org.robolectric:playservices` and `org.robolectric:httpclient`).
 > - Before Robolectric 3.4, `org.robolectric:playservices` was named `shadow-play-services`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,9 +48,11 @@ extra_css:
   - stylesheets/extra.css
 
 markdown_extensions:
+  - admonition
   - attr_list
   - github-callouts
   - md_in_html
+  - pymdownx.details
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span


### PR DESCRIPTION
This PR creates a new workflow to lint Markdown files. This was suggested here: https://github.com/robolectric/robolectric.github.io/pull/255#discussion_r1660106328.

The new workflow uses the [`DavidAnson/markdownlint-cli2-action`](https://github.com/marketplace/actions/markdownlint-cli2-action) action. It uses the rules defined in [`DavidAnson/markdownlint`](https://github.com/DavidAnson/markdownlint).

For the moment, I've kept the default configuration (ie. all the rules are enabled), and modified the maximum line length to be 120 characters, instead of 80.
A sample output is available here: https://github.com/robolectric/robolectric.github.io/actions/runs/9766776527/job/26960490077?pr=265.

I didn't modify any Markdown file yet, because I think that it's better to agree on the rules first. Once that's done, I'll fix all the Markdown files.

The original suggestion was to only enforce max line length. That's possible with the action I'm using. We just need to agree on the value to use.