### PR TITLE
Enable the `content.tabs.link` feature

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ theme:
   features:
     - content.action.view
     - content.code.copy
+    - content.tabs.link
     - content.tooltips
     - navigation.indexes
     - navigation.sections


### PR DESCRIPTION
This feature links tabs label across the website.
So if the user selects the "Kotlin" tab on one page, every Kotlin code sample will be shown by default.

See the documentation for more details: https://squidfunk.github.io/mkdocs-material/reference/content-tabs/#linked-content-tabs