### PR TITLE
Update the `Using add-on modules` page

### DIFF
--- a/docs/using-add-on-modules.md
+++ b/docs/using-add-on-modules.md
@@ -1,19 +1,27 @@
----
-hide:
-- toc
----
+# Using add-on modules
 
-# Using Add-On Modules
+In order to reduce the number of external dependencies on the application being tested, Robolectric's shadows are split into various add-on packages. Only shadows for classes provided in the base Android SDK are provided by the main Robolectric module. Additional shadows are provided in dedicated packages.
 
-In order to reduce the number of external dependencies on the application being tested, Robolectric's shadows are split into various add-on packages. Only shadows for classes provided in the base Android SDK are provided by the main Robolectric module. Additional shadows for things like appcompat or the support library are provided by add-on modules. The table below lists the available add-on shadow packages:
+> [!NOTE]
+> - [Robolectric 3.4](https://github.com/robolectric/robolectric/releases/tag/robolectric-3.4) doesn't include the `shadows-` prefix in the package name (i.e., `org.robolectric:playservices` and `org.robolectric:httpclient`).
+> - Before Robolectric 3.4, `org.robolectric:playservices` was named `shadow-play-services`.
 
-| SDK Package                          | Robolectric Add-On Package            |
-|--------------------------------------|---------------------------------------|
-| com.android.support.support-v4       | org.robolectric:shadows-supportv4    |
-| com.android.support.multidex         | org.robolectric:shadows-multidex      |
-| com.google.android.gms:play-services | org.robolectric:shadows-playservices |
-| org.apache.httpcomponents:httpclient | org.robolectric:shadows-httpclient    |
+## Supported packages
 
-The above artifact names are in use since [Robolectric 3.5](https://github.com/robolectric/robolectric/releases/tag/robolectric-3.5). [Robolectric 3.4](https://github.com/robolectric/robolectric/releases/tag/robolectric-3.4) drops `shadows-` prefix from artifact names. Prior to 3.4, all artifact names are the same as latest, except that `shadows-supportv4` and `shadow-playservices` are `shadows-support-v4` and `shadow-play-services` respectively.
+| SDK package | Robolectric add-on package | Javadoc |
+|-----|-----|-----|
+| `androidx.multidex.MultiDex` | [`org.robolectric:shadows-multidex`](https://github.com/robolectric/robolectric/tree/robolectric-4.13/shadows/multidex) | [Javadoc](javadoc/latest/org/robolectric/shadows/multidex/package-summary.html) |
+| `com.android.support.multidex` | [`org.robolectric:shadows-multidex`](https://github.com/robolectric/robolectric/tree/robolectric-4.13/shadows/multidex) | [Javadoc](javadoc/latest/org/robolectric/shadows/multidex/package-summary.html) |
+| `com.google.android.gms:play-services` | [`org.robolectric:shadows-playservices`](https://github.com/robolectric/robolectric/tree/robolectric-4.13/shadows/playservices) | [Javadoc](javadoc/latest/org/robolectric/shadows/gms/package-summary.html) |
 
-Note that `org.robolectric:shadows-supportv4` was deprecated at [Robolectric 4.8](https://github.com/robolectric/robolectric/releases/tag/robolectric-4.8), and was removed at [Robolectric 4.9](https://github.com/robolectric/robolectric/releases/tag/robolectric-4.9).
+## Deprecated packages
+
+| SDK package | Robolectric add-on package | Javadoc | Comment |
+|-----|-----|-----|-----|
+| `org.apache.httpcomponents:httpclient` | [`org.robolectric:shadows-httpclient`](https://github.com/robolectric/robolectric/tree/robolectric-4.13/shadows/httpclient) | [Javadoc](javadoc/latest/org/robolectric/shadows/httpclient/package-summary.html) | These shadows are only provided for legacy compatibility. |
+
+## Removed packages
+
+| SDK package | Robolectric add-on package | Comment |
+|-----|-----|-----|
+| `com.android.support.support-v4` | `org.robolectric:shadows-supportv4` | This package was deprecated in [Robolectric 4.8](https://github.com/robolectric/robolectric/releases/tag/robolectric-4.8), and removed in [Robolectric 4.9](https://github.com/robolectric/robolectric/releases/tag/robolectric-4.9). |


### PR DESCRIPTION
This PR updates the [`Using add-on modules`](https://robolectric.org/using-add-on-modules/) page.

The changes are:
- Separate supported, deprecated, and removed modules for clarity.
- Add links to external documentation where possible.

@hoisie @brettchabot this PR officially deprecates the `shadows-multidex` module. Are you ok with that? This was discussed in https://github.com/robolectric/robolectric/pull/9266, but no actual decision was made.

![Screenshot 2024-09-03 at 13 20 14](https://github.com/user-attachments/assets/9bd9e3ae-cb51-494d-8686-0b7d92f8d040)