### PR TITLE
Move `shadows-multidex` to the deprecated section

### DIFF
--- a/docs/using-add-on-modules.md
+++ b/docs/using-add-on-modules.md
@@ -15,15 +15,15 @@ dedicated packages.
 
 | SDK package                            | Robolectric add-on package                                            | Javadoc                                 |
 |----------------------------------------|-----------------------------------------------------------------------|-----------------------------------------|
-| `androidx.multidex.MultiDex`           | [`org.robolectric:shadows-multidex`][shadows-multidex-source]         | [Javadoc][shadows-multidex-javadoc]     |
-| `com.android.support.multidex`         | [`org.robolectric:shadows-multidex`][shadows-multidex-source]         | [Javadoc][shadows-multidex-javadoc]     |
 | `com.google.android.gms:play-services` | [`org.robolectric:shadows-playservices`][shadows-playservices-source] | [Javadoc][shadows-playservices-javadoc] |
 
 ## Deprecated packages
 
-| SDK package                            | Robolectric add-on package                                        | Javadoc                               | Comment                                                   |
-|----------------------------------------|-------------------------------------------------------------------|---------------------------------------|-----------------------------------------------------------|
-| `org.apache.httpcomponents:httpclient` | [`org.robolectric:shadows-httpclient`][shadows-httpclient-source] | [Javadoc][shadows-httpclient-javadoc] | These shadows are only provided for legacy compatibility. |
+| SDK package                            | Robolectric add-on package                                        | Javadoc                               | Comment                                                                      |
+|----------------------------------------|-------------------------------------------------------------------|---------------------------------------|------------------------------------------------------------------------------|
+| `androidx.multidex.MultiDex`           | [`org.robolectric:shadows-multidex`][shadows-multidex-source]     | [Javadoc][shadows-multidex-javadoc]   | This package was deprecated in [Robolectric 4.14][robolectric-4.14-release]. |
+| `com.android.support.multidex`         | [`org.robolectric:shadows-multidex`][shadows-multidex-source]     | [Javadoc][shadows-multidex-javadoc]   | This package was deprecated in [Robolectric 4.14][robolectric-4.14-release]. |
+| `org.apache.httpcomponents:httpclient` | [`org.robolectric:shadows-httpclient`][shadows-httpclient-source] | [Javadoc][shadows-httpclient-javadoc] | These shadows are only provided for legacy compatibility.                    |
 
 ## Removed packages
 
@@ -34,6 +34,7 @@ dedicated packages.
 [robolectric-3.4-release]: https://github.com/robolectric/robolectric/releases/tag/robolectric-3.4
 [robolectric-4.8-release]: https://github.com/robolectric/robolectric/releases/tag/robolectric-4.8
 [robolectric-4.9-release]: https://github.com/robolectric/robolectric/releases/tag/robolectric-4.9
+[robolectric-4.14-release]: https://github.com/robolectric/robolectric/releases/tag/robolectric-4.14
 [shadows-httpclient-javadoc]: javadoc/latest/org/robolectric/shadows/httpclient/package-summary.html
 [shadows-httpclient-source]: https://github.com/robolectric/robolectric/tree/master/shadows/httpclient
 [shadows-multidex-javadoc]: javadoc/latest/org/robolectric/shadows/multidex/package-summary.html


### PR DESCRIPTION
This follows the merge of https://github.com/robolectric/robolectric/pull/9728

I've put the PR in draft to prepare the change. But I think it can wait for the stable 4.14 release to be merged.