### PR TITLE
Migrate from `pymdownx.tabbed` to `pymdownx.blocks.tab`

### DIFF
--- a/docs/androidx_test.md
+++ b/docs/androidx_test.md
@@ -16,45 +16,45 @@ us know if there are any extension points missing that you require.
 
 !!! snippet "Robolectric"
 
-    === "Java"
+    /// tab | Java
+    ```java
+    import org.robolectric.RobolectricTestRunner;
 
-        ```java
-        import org.robolectric.RobolectricTestRunner;
+    @RunWith(RobolectricTestRunner.class)
+    public class SandwichTest {
+    }
+    ```
+    ///
 
-        @RunWith(RobolectricTestRunner.class)
-        public class SandwichTest {
-        }
-        ```
+    /// tab | Kotlin
+    ```kotlin
+    import org.robolectric.RobolectricTestRunner
 
-    === "Kotlin"
-
-        ```kotlin
-        import org.robolectric.RobolectricTestRunner
-
-        @RunWith(RobolectricTestRunner::class)
-        class SandwichTest
-        ```
+    @RunWith(RobolectricTestRunner::class)
+    class SandwichTest
+    ```
+    ///
 
 !!! snippet "AndroidX Test"
 
-    === "Java"
+    /// tab | Java
+    ```java
+    import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-        ```java
-        import androidx.test.ext.junit.runners.AndroidJUnit4;
+    @RunWith(AndroidJUnit4.class)
+    public class SandwichTest {
+    }
+    ```
+    ///
 
-        @RunWith(AndroidJUnit4.class)
-        public class SandwichTest {
-        }
-        ```
+    /// tab | Kotlin
+    ```kotlin
+    import androidx.test.ext.junit.runners.AndroidJUnit4
 
-    === "Kotlin"
-
-        ```kotlin
-        import androidx.test.ext.junit.runners.AndroidJUnit4
-
-        @RunWith(AndroidJUnit4::class)
-        class SandwichTest
-        ```
+    @RunWith(AndroidJUnit4::class)
+    class SandwichTest
+    ```
+    ///
 
 ## Application
 
@@ -63,55 +63,55 @@ application’s context is a typical task for most tests.
 
 !!! snippet "Robolectric"
 
-    === "Java"
+    /// tab | Java
+    ```java
+    import org.robolectric.RuntimeEnvironment;
 
-        ```java
-        import org.robolectric.RuntimeEnvironment;
+    @Before
+    void setUp() {
+      ExampleApplication app = (ExampleApplication) RuntimeEnvironment.application;
+      app.setLocationProvider(mockLocationProvider);
+    }
+    ```
+    ///
 
-        @Before
-        void setUp() {
-          ExampleApplication app = (ExampleApplication) RuntimeEnvironment.application;
-          app.setLocationProvider(mockLocationProvider);
-        }
-        ```
+    /// tab | Kotlin
+    ```kotlin
+    import org.robolectric.RuntimeEnvironment
 
-    === "Kotlin"
-
-        ```kotlin
-        import org.robolectric.RuntimeEnvironment
-
-        @Before
-        fun setUp() {
-          val app = RuntimeEnvironment.application as ExampleApplication
-          app.setLocationProvider(mockLocationProvider)
-        }
-        ```
+    @Before
+    fun setUp() {
+      val app = RuntimeEnvironment.application as ExampleApplication
+      app.setLocationProvider(mockLocationProvider)
+    }
+    ```
+    ///
 
 !!! snippet "AndroidX Test"
 
-    === "Java"
+    /// tab | Java
+    ```java
+    import androidx.test.core.app.ApplicationProvider;
 
-        ```java
-        import androidx.test.core.app.ApplicationProvider;
+    @Before
+    void setUp() {
+      ExampleApplication app = ApplicationProvider.getApplicationContext<ExampleApplication>();
+      app.setLocationProvider(mockLocationProvider);
+    }
+    ```
+    ///
 
-        @Before
-        void setUp() {
-          ExampleApplication app = ApplicationProvider.getApplicationContext<ExampleApplication>();
-          app.setLocationProvider(mockLocationProvider);
-        }
-        ```
+    /// tab | Kotlin
+    ```kotlin
+    import androidx.test.core.app.ApplicationProvider
 
-    === "Kotlin"
-
-        ```kotlin
-        import androidx.test.core.app.ApplicationProvider
-
-        @Before
-        fun setUp() {
-          val app = ApplicationProvider.getApplicationContext<ExampleApplication>()
-          app.setLocationProvider(mockLocationProvider)
-        }
-        ```
+    @Before
+    fun setUp() {
+      val app = ApplicationProvider.getApplicationContext<ExampleApplication>()
+      app.setLocationProvider(mockLocationProvider)
+    }
+    ```
+    ///
 
 ## Activities
 
@@ -133,92 +133,92 @@ transitions are not possible. If you'd like a [`Rule`][junit-rule]-based equival
 
 !!! snippet "Robolectric"
 
-    === "Java"
+    /// tab | Java
+    ```java
+    import org.robolectric.Robolectric;
+    import org.robolectric.android.controller.ActivityController;
 
-        ```java
-        import org.robolectric.Robolectric;
-        import org.robolectric.android.controller.ActivityController;
+    public class LocationTrackerActivityTest {
+        @Test
+        public void locationListenerShouldBeUnregisteredInCreatedState() {
+            // GIVEN
+            ActivityController<LocationTrackerActivity> controller = Robolectric.buildActivity<LocationTrackerActivity>().setup();
 
-        public class LocationTrackerActivityTest {
-            @Test
-            public void locationListenerShouldBeUnregisteredInCreatedState() {
-                // GIVEN
-                ActivityController<LocationTrackerActivity> controller = Robolectric.buildActivity<LocationTrackerActivity>().setup();
+            // WHEN
+            controller.pause().stop();
 
-                // WHEN
-                controller.pause().stop();
+            // THEN
+            assertThat(controller.get().getLocationListener()).isNull();
+         }
+    }
+    ```
+    ///
 
-                // THEN
-                assertThat(controller.get().getLocationListener()).isNull();
-             }
-        }
-        ```
+    /// tab | Kotlin
+    ```kotlin
+    import org.robolectric.Robolectric
 
-    === "Kotlin"
+    class LocationTrackerActivityTest {
+        @Test
+        fun locationListenerShouldBeUnregisteredInCreatedState() {
+            // GIVEN
+            val controller = Robolectric.buildActivity<LocationTrackerActivity>().setup()
 
-        ```kotlin
-        import org.robolectric.Robolectric
+            // WHEN
+            controller.pause().stop()
 
-        class LocationTrackerActivityTest {
-            @Test
-            fun locationListenerShouldBeUnregisteredInCreatedState() {
-                // GIVEN
-                val controller = Robolectric.buildActivity<LocationTrackerActivity>().setup()
-
-                // WHEN
-                controller.pause().stop()
-
-                // THEN
-                assertThat(controller.get().locationListener).isNull()
-             }
-        }
-        ```
+            // THEN
+            assertThat(controller.get().locationListener).isNull()
+         }
+    }
+    ```
+    ///
 
 !!! snippet "AndroidX Test"
 
-    === "Java"
+    /// tab | Java
+    ```java
+    import androidx.lifecycle.Lifecycle;
+    import androidx.test.core.app.ActivityScenario;
 
-        ```java
-        import androidx.lifecycle.Lifecycle;
-        import androidx.test.core.app.ActivityScenario;
+    public class LocationTrackerActivityTest {
+        @Test
+        public void locationListenerShouldBeUnregisteredInCreatedState() {
+            // GIVEN
+            ActivityScenario<LocationTrackerActivity> scenario = ActivityScenario.launchActivity<LocationTrackerActivity>();
 
-        public class LocationTrackerActivityTest {
-            @Test
-            public void locationListenerShouldBeUnregisteredInCreatedState() {
-                // GIVEN
-                ActivityScenario<LocationTrackerActivity> scenario = ActivityScenario.launchActivity<LocationTrackerActivity>();
+            // WHEN
+            scenario.moveToState(Lifecycle.State.CREATED);
 
-                // WHEN
-                scenario.moveToState(Lifecycle.State.CREATED);
+            // THEN
+            scenario.onActivity(activity -> assertThat(activity.getLocationListener()).isNull());
+        }
+    }
+    ```
+    ///
 
-                // THEN
-                scenario.onActivity(activity -> assertThat(activity.getLocationListener()).isNull());
+    /// tab | Kotlin
+    ```kotlin
+    import androidx.lifecycle.Lifecycle
+    import androidx.test.core.app.ActivityScenario
+
+    class LocationTrackerActivityTest {
+        @Test
+        fun locationListenerShouldBeUnregisteredInCreatedState() {
+            // GIVEN
+            val scenario = ActivityScenario.launchActivity<LocationTrackerActivity>()
+
+            // WHEN
+            scenario.moveToState(Lifecycle.State.CREATED)
+
+            // THEN
+            scenario.onActivity { activity ->
+                assertThat(activity.locationListener).isNull()
             }
         }
-        ```
-
-    === "Kotlin"
-
-        ```kotlin
-        import androidx.lifecycle.Lifecycle
-        import androidx.test.core.app.ActivityScenario
-
-        class LocationTrackerActivityTest {
-            @Test
-            fun locationListenerShouldBeUnregisteredInCreatedState() {
-                // GIVEN
-                val scenario = ActivityScenario.launchActivity<LocationTrackerActivity>()
-
-                // WHEN
-                scenario.moveToState(Lifecycle.State.CREATED)
-
-                // THEN
-                scenario.onActivity { activity ->
-                    assertThat(activity.locationListener).isNull()
-                }
-            }
-        }
-        ```
+    }
+    ```
+    ///
 
 Note that in Robolectric since both the test and UI event loop run on the same thread,
 synchronization is not an issue. [`ActivityScenario.onActivity`][activity-scenario-on-activity]
@@ -235,96 +235,96 @@ UI threads.
 [Espresso][espresso] is the `View` matching and interaction library of choice for instrumentation
 tests. Since Robolectric 4.0, Espresso APIs are now supported in Robolectric tests.
 
-=== "Java"
+/// tab | Java
+```java
+import static androidx.test.espresso.Espresso.onView;
 
-    ```java
-    import static androidx.test.espresso.Espresso.onView;
+@RunWith(AndroidJUnit4.class)
+public class AddContactActivityTest {
+    @Test
+    public void inputTextShouldBeRetainedAfterActivityRecreation() {
+        // GIVEN
+        String contactName = "Test User";
+        ActivityScenario<AddContactActivity> scenario = ActivityScenario.launchActivity<AddContactActivity>();
 
-    @RunWith(AndroidJUnit4.class)
-    public class AddContactActivityTest {
-        @Test
-        public void inputTextShouldBeRetainedAfterActivityRecreation() {
-            // GIVEN
-            String contactName = "Test User";
-            ActivityScenario<AddContactActivity> scenario = ActivityScenario.launchActivity<AddContactActivity>();
-    
-            // WHEN
-            // Enter contact name
-            onView(withId(R.id.contact_name_text)).perform(typeText(contactName));
-            // Destroy and recreate Activity
-            scenario.recreate();
-    
-            // THEN
-            // Check contact name was preserved.
-            onView(withId(R.id.contact_name_text)).check(matches(withText(contactName)));
-         }
-    }
-    ```
+        // WHEN
+        // Enter contact name
+        onView(withId(R.id.contact_name_text)).perform(typeText(contactName));
+        // Destroy and recreate Activity
+        scenario.recreate();
 
-=== "Kotlin"
+        // THEN
+        // Check contact name was preserved.
+        onView(withId(R.id.contact_name_text)).check(matches(withText(contactName)));
+     }
+}
+```
+///
 
-    ```kotlin
-    import androidx.test.espresso.Espresso.onView
+/// tab | Kotlin
+```kotlin
+import androidx.test.espresso.Espresso.onView
 
-    @RunWith(AndroidJUnit4::class)
-    class AddContactActivityTest {
-        @Test
-        fun inputTextShouldBeRetainedAfterActivityRecreation() {
-            // GIVEN
-            val contactName = "Test User"
-            val scenario = ActivityScenario.launchActivity<AddContactActivity>()
-    
-            // WHEN
-            // Enter contact name
-            onView(withId(R.id.contact_name_text)).perform(typeText(contactName))
-            // Destroy and recreate Activity
-            scenario.recreate()
-    
-            // THEN
-            // Check contact name was preserved.
-            onView(withId(R.id.contact_name_text)).check(matches(withText(contactName)))
-         }
-    }
-    ```
+@RunWith(AndroidJUnit4::class)
+class AddContactActivityTest {
+    @Test
+    fun inputTextShouldBeRetainedAfterActivityRecreation() {
+        // GIVEN
+        val contactName = "Test User"
+        val scenario = ActivityScenario.launchActivity<AddContactActivity>()
+
+        // WHEN
+        // Enter contact name
+        onView(withId(R.id.contact_name_text)).perform(typeText(contactName))
+        // Destroy and recreate Activity
+        scenario.recreate()
+
+        // THEN
+        // Check contact name was preserved.
+        onView(withId(R.id.contact_name_text)).check(matches(withText(contactName)))
+     }
+}
+```
+///
 
 ## Fragments
 
 AndroidX Test provides [`FragmentScenario`][fragment-scenario], which offers APIs to safely create
 your [`Fragment`][fragment-documentation] under test and drive it through valid transitions.
 
-=== "Java"
+/// tab | Java
+```java
+import androidx.fragment.app.testing.FragmentScenario;
 
-    ```java
-    import androidx.fragment.app.testing.FragmentScenario;
-
-    @RunWith(AndroidJUnit4.class)
-    public class FragmentTest {
-        @Test
-        public void testEventFragment() {
-            Bundle arguments = Bundle();
-            MyFragmentFactory factory = MyFragmentFactory();
-            FragmentScenario<MyFragment> scenario = FragmentScenario.launchFragmentInContainer<MyFragment>(arguments, factory);
-            onView(withId(R.id.text)).check(matches(withText("Hello World!")));
-        }
+@RunWith(AndroidJUnit4.class)
+public class FragmentTest {
+    @Test
+    public void testEventFragment() {
+        Bundle arguments = Bundle();
+        MyFragmentFactory factory = MyFragmentFactory();
+        FragmentScenario<MyFragment> scenario = FragmentScenario.launchFragmentInContainer<MyFragment>(arguments, factory);
+        onView(withId(R.id.text)).check(matches(withText("Hello World!")));
     }
-    ```
+}
+```
+///
 
-=== "Kotlin"
+/// tab | Kotlin
+```kotlin
+import androidx.fragment.app.testing.FragmentScenario
 
-    ```kotlin
-    import androidx.fragment.app.testing.FragmentScenario
-
-    @RunWith(AndroidJUnit4::class)
-    class FragmentTest {
-        @Test
-        fun testEventFragment() {
-            val arguments = Bundle()
-            val factory = MyFragmentFactory()
-            val scenario = FragmentScenario.launchFragmentInContainer<MyFragment>(arguments, factory)
-            onView(withId(R.id.text)).check(matches(withText("Hello World!")))
-        }
+@RunWith(AndroidJUnit4::class)
+class FragmentTest {
+    @Test
+    fun testEventFragment() {
+        val arguments = Bundle()
+        val factory = MyFragmentFactory()
+        val scenario = FragmentScenario.launchFragmentInContainer<MyFragment>(arguments, factory)
+        onView(withId(R.id.text)).check(matches(withText("Hello World!")))
     }
-    ```
+}
+```
+///
 
 Read more about testing Fragments [here][fragment-testing].
 

--- a/docs/automated-migration.md
+++ b/docs/automated-migration.md
@@ -21,55 +21,55 @@ and commit to your source control system.
 2. [Configure your project][error-prone-setup] to integrate Error Prone. Quick config for Gradle (
    usually in your module's `build.gradle`/`build.gradle.kts` file):
 
-=== "Groovy"
+/// tab | Groovy
+```groovy
+plugins {
+   id "net.ltgt.errorprone" version "<error_prone_plugin_version>" apply false
+}
 
-    ```groovy
-    plugins {
-        id "net.ltgt.errorprone" version "<error_prone_plugin_version>" apply false
-    }
+String robolectricMigrations = System.getenv("ROBOLECTRIC_MIGRATIONS")
+if (robolectricMigrations) {
+   apply plugin: "net.ltgt.errorprone"
 
-    String robolectricMigrations = System.getenv("ROBOLECTRIC_MIGRATIONS")
-    if (robolectricMigrations) {
-        apply plugin: "net.ltgt.errorprone"
+   dependencies {
+      errorprone "com.google.errorprone:error_prone_core:<error_prone_version>"
+      errorprone "org.robolectric:errorprone:{{ robolectric.version.current }}"
+   }
 
-        dependencies {
-            errorprone "com.google.errorprone:error_prone_core:<error_prone_version>"
-            errorprone "org.robolectric:errorprone:{{ robolectric.version.current }}"
-        }
+   tasks.withType(JavaCompile).configureEach {
+      options.errorprone.errorproneArgs = [
+              '-XepPatchChecks:' + robolectricMigrations,
+              '-XepPatchLocation:IN_PLACE',
+      ]
+   }
+}
+```
+///
 
-         tasks.withType(JavaCompile).configureEach {
-             options.errorprone.errorproneArgs = [
-                  '-XepPatchChecks:' + robolectricMigrations,
-                  '-XepPatchLocation:IN_PLACE',
-             ]
-         }
-    }
-    ```
+/// tab | Kotlin
+```kotlin
+plugins {
+   id("net.ltgt.errorprone") version "<error_prone_plugin_version>" apply false
+}
 
-=== "Kotlin"
+val robolectricMigrations = System.getenv("ROBOLECTRIC_MIGRATIONS")
+if (!robolectricMigrations.isNullOrEmpty()) {
+   pluginManager.apply("net.ltgt.errorprone")
 
-    ```kotlin
-    plugins {
-        id("net.ltgt.errorprone") version "<error_prone_plugin_version>" apply false
-    }
+   dependencies {
+      errorprone("com.google.errorprone:error_prone_core:<error_prone_version>")
+      errorprone("org.robolectric:errorprone:{{ robolectric.version.current }}")
+   }
 
-    val robolectricMigrations = System.getenv("ROBOLECTRIC_MIGRATIONS")
-    if (!robolectricMigrations.isNullOrEmpty()) {
-        pluginManager.apply("net.ltgt.errorprone")
-
-        dependencies {
-            errorprone("com.google.errorprone:error_prone_core:<error_prone_version>")
-            errorprone("org.robolectric:errorprone:{{ robolectric.version.current }}")
-        }
-
-         tasks.withType<JavaCompile>().configureEach {
-             options.errorprone.errorproneArgs = listOf(
-                  "-XepPatchChecks:$robolectricMigrations",
-                  "-XepPatchLocation:IN_PLACE",
-             )
-         }
-    }
-    ```
+   tasks.withType<JavaCompile>().configureEach {
+      options.errorprone.errorproneArgs = listOf(
+         "-XepPatchChecks:$robolectricMigrations",
+         "-XepPatchLocation:IN_PLACE",
+      )
+   }
+}
+```
+///
 
     You don't need to commit this change.
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -16,26 +16,26 @@ Base classes are also searched for annotations. So if you find yourself specifyi
 on a large number of tests, you can create a base class and move your `@Config` annotation to that
 class.
 
-=== "Java"
+/// tab | Java
+```java
+@Config(
+  sdk = Build.VERSION_CODES.TIRAMISU,
+  shadows = {ShadowFoo.class, ShadowBar.class}
+)
+public class SandwichTest {
+}
+```
+///
 
-    ```java
-    @Config(
-      sdk = Build.VERSION_CODES.TIRAMISU,
-      shadows = { ShadowFoo.class, ShadowBar.class }
-    )
-    public class SandwichTest {
-    }
-    ```
-
-=== "Kotlin"
-
-    ```kotlin
-    @Config(
-      sdk = Build.VERSION_CODES.TIRAMISU,
-      shadows = [ ShadowFoo.class, ShadowBar.class ]
-    )
-    class SandwichTest
-    ```
+/// tab | Kotlin
+```kotlin
+@Config(
+  sdk = Build.VERSION_CODES.TIRAMISU,
+  shadows = [ShadowFoo::class, ShadowBar::class]
+)
+class SandwichTest
+```
+///
 
 ### `robolectric.properties` file
 
@@ -74,53 +74,53 @@ By default, Robolectric will run your code against the `targetSdk` specified in 
 a different SDK, you can specify the desired SDK(s) using the [`sdk`][config-sdk],
 [`minSdk`][config-min-sdk] and [`maxSdk`][config-max-sdk] config properties:
 
-=== "Java"
+/// tab | Java
+```java
+@Config(sdk = {TIRAMISU, UPSIDE_DOWN_CAKE})
+public class SandwichTest {
+  @Test
+  public void getSandwich_shouldReturnHamSandwich() {
+    // will run on TIRAMISU and UPSIDE_DOWN_CAKE
+  }
 
-    ```java
-    @Config(sdk = { TIRAMISU, UPSIDE_DOWN_CAKE })
-    public class SandwichTest {
-        @Test
-        public void getSandwich_shouldReturnHamSandwich() {
-          // will run on TIRAMISU and UPSIDE_DOWN_CAKE
-        }
+  @Test
+  @Config(sdk = TIRAMISU)
+  public void onTiramisu_getSandwich_shouldReturnChocolateWaferSandwich() {
+    // will run on TIRAMISU
+  }
 
-        @Test
-        @Config(sdk = TIRAMISU)
-        public void onTiramisu_getSandwich_shouldReturnChocolateWaferSandwich() {
-          // will run on TIRAMISU
-        }
+  @Test
+  @Config(minSdk = UPSIDE_DOWN_CAKE)
+  public void fromUpsideDownCakeOn_getSandwich_shouldReturnTunaSandwich() {
+    // will run on UPSIDE_DOWN_CAKE, VANILLA_ICE_CREAM, etc.
+  }
+}
+```
+///
 
-        @Test
-        @Config(minSdk = UPSIDE_DOWN_CAKE)
-        public void fromUpsideDownCakeOn_getSandwich_shouldReturnTunaSandwich() {
-          // will run on UPSIDE_DOWN_CAKE, VANILLA_ICE_CREAM, etc.
-        }
-    }
-    ```
+/// tab | Kotlin
+```kotlin
+@Config(sdk = [TIRAMISU, UPSIDE_DOWN_CAKE])
+class SandwichTest {
+  @Test
+  fun getSandwich_shouldReturnHamSandwich() {
+    // will run on TIRAMISU and UPSIDE_DOWN_CAKE
+  }
 
-=== "Kotlin"
+  @Test
+  @Config(sdk = TIRAMISU)
+  fun onTiramisu_getSandwich_shouldReturnChocolateWaferSandwich() {
+    // will run on TIRAMISU
+  }
 
-    ```kotlin
-    @Config(sdk = [ TIRAMISU, UPSIDE_DOWN_CAKE ])
-    class SandwichTest {
-        @Test
-        fun getSandwich_shouldReturnHamSandwich() {
-          // will run on TIRAMISU and UPSIDE_DOWN_CAKE
-        }
-
-        @Test
-        @Config(sdk = TIRAMISU)
-        fun onTiramisu_getSandwich_shouldReturnChocolateWaferSandwich() {
-          // will run on TIRAMISU
-        }
-
-        @Test
-        @Config(minSdk = UPSIDE_DOWN_CAKE)
-        fun fromUpsideDownCakeOn_getSandwich_shouldReturnTunaSandwich() {
-          // will run on UPSIDE_DOWN_CAKE, VANILLA_ICE_CREAM, etc.
-        }
-    }
-    ```
+  @Test
+  @Config(minSdk = UPSIDE_DOWN_CAKE)
+  fun fromUpsideDownCakeOn_getSandwich_shouldReturnTunaSandwich() {
+    // will run on UPSIDE_DOWN_CAKE, VANILLA_ICE_CREAM, etc.
+  }
+}
+```
+///
 
 Note that `sdk` and `minSdk`/`maxSdk` may not be specified in the same `@Config` annotation or file;
 however, `minSdk` and `maxSdk` may be specified together. If any of them is present, they override
@@ -138,57 +138,57 @@ Robolectric will attempt to create an instance of your [`Application`][applicati
 class as specified in the `AndroidManifest`. If you want to provide a custom implementation, you can
 specify it by setting:
 
-=== "Java"
+/// tab | Java
+```java
+@Config(application = CustomApplication.class)
+public class SandwichTest {
+  @Test
+  @Config(application = CustomApplicationOverride.class)
+  public void getSandwich_shouldReturnHamSandwich() {
+  }
+}
+```
+///
 
-    ```java
-    @Config(application = CustomApplication.class)
-    public class SandwichTest {
-        @Test
-        @Config(application = CustomApplicationOverride.class)
-        public void getSandwich_shouldReturnHamSandwich() {
-        }
-    }
-    ```
-
-=== "Kotlin"
-
-    ```kotlin
-    @Config(application = CustomApplication::class)
-    class SandwichTest {
-        @Test
-        @Config(application = CustomApplicationOverride.class)
-        fun getSandwich_shouldReturnHamSandwich() {
-        }
-    }
-    ```
+/// tab | Kotlin
+```kotlin
+@Config(application = CustomApplication::class)
+class SandwichTest {
+  @Test
+  @Config(application = CustomApplicationOverride::class)
+  fun getSandwich_shouldReturnHamSandwich() {
+  }
+}
+```
+///
 
 ### Configure qualifiers
 
 You can explicitly configure the set of resource qualifiers in effect for a test:
 
-=== "Java"
+/// tab | Java
+```java
+public class SandwichTest {
+  @Test
+  @Config(qualifiers = "fr-xlarge")
+  public void getSandwichName() {
+    assertThat(sandwich.getName()).isEqualTo("Grande Croque Monégasque");
+  }
+}
+```
+///
 
-    ```java
-    public class SandwichTest {
-        @Test
-        @Config(qualifiers = "fr-xlarge")
-        public void getSandwichName() {
-          assertThat(sandwich.getName()).isEqualTo("Grande Croque Monégasque");
-        }
-    }
-    ```
-
-=== "Kotlin"
-
-    ```kotlin
-    class SandwichTest {
-        @Test
-        @Config(qualifiers = "fr-xlarge")
-        fun getSandwichName() {
-          assertThat(sandwich.name).isEqualTo("Grande Croque Monégasque")
-        }
-    }
-    ```
+/// tab | Kotlin
+```kotlin
+class SandwichTest {
+  @Test
+  @Config(qualifiers = "fr-xlarge")
+  fun getSandwichName() {
+    assertThat(sandwich.name).isEqualTo("Grande Croque Monégasque")
+  }
+}
+```
+///
 
 See [Using Qualified Resources](using-qualifiers.md) for more details.
 
@@ -220,47 +220,47 @@ When using Gradle, you can configure the System Properties for unit tests with t
 to override the Maven repository URL and ID to download the runtime dependencies from a repository
 other than Maven Central:
 
-=== "Groovy"
+/// tab | Groovy
+```groovy
+android {
+  testOptions {
+    unitTests.all {
+      systemProperty "robolectric.dependency.repo.url", "https://local-mirror/repo"
+      systemProperty "robolectric.dependency.repo.id", "local"
 
-    ```groovy
-    android {
-      testOptions {
-        unitTests.all {
-          systemProperty "robolectric.dependency.repo.url", "https://local-mirror/repo"
-          systemProperty "robolectric.dependency.repo.id", "local"
+      // Username and password only needed when the local repository needs account information.
+      systemProperty "robolectric.dependency.repo.username", "username"
+      systemProperty "robolectric.dependency.repo.password", "password"
 
-          // Username and password only needed when the local repository needs account information.
-          systemProperty "robolectric.dependency.repo.username", "username"
-          systemProperty "robolectric.dependency.repo.password", "password"
-
-          // Since Robolectric 4.9.1, these are available
-          systemProperty "robolectric.dependency.proxy.host", project.findProperty("systemProp.https.proxyHost") ?: System.getenv("ROBOLECTRIC_PROXY_HOST")
-          systemProperty "robolectric.dependency.proxy.port", project.findProperty("systemProp.https.proxyPort") ?: System.getenv("ROBOLECTRIC_PROXY_PORT")
-        }
-      }
+      // Since Robolectric 4.9.1, these are available
+      systemProperty "robolectric.dependency.proxy.host", project.findProperty("systemProp.https.proxyHost") ?: System.getenv("ROBOLECTRIC_PROXY_HOST")
+      systemProperty "robolectric.dependency.proxy.port", project.findProperty("systemProp.https.proxyPort") ?: System.getenv("ROBOLECTRIC_PROXY_PORT")
     }
-    ```
+  }
+}
+```
+///
 
-=== "Kotlin"
+/// tab | Kotlin
+```kotlin
+android {
+  testOptions {
+    unitTests.all {
+      it.systemProperty("robolectric.dependency.repo.url", "https://local-mirror/repo")
+      it.systemProperty("robolectric.dependency.repo.id", "local")
 
-    ```kotlin
-    android {
-      testOptions {
-        unitTests.all {
-          it.systemProperty("robolectric.dependency.repo.url", "https://local-mirror/repo")
-          it.systemProperty("robolectric.dependency.repo.id", "local")
+      // Username and password only needed when the local repository needs account information.
+      it.systemProperty("robolectric.dependency.repo.username", "username")
+      it.systemProperty("robolectric.dependency.repo.password", "password")
 
-          // Username and password only needed when the local repository needs account information.
-          it.systemProperty("robolectric.dependency.repo.username", "username")
-          it.systemProperty("robolectric.dependency.repo.password", "password")
-
-          // Since Robolectric 4.9.1, these are available
-          it.systemProperty("robolectric.dependency.proxy.host", project.findProperty("systemProp.https.proxyHost") ?: System.getenv("ROBOLECTRIC_PROXY_HOST"))
-          it.systemProperty("robolectric.dependency.proxy.port", project.findProperty("systemProp.https.proxyPort") ?: System.getenv("ROBOLECTRIC_PROXY_PORT"))
-        }
-      }
+      // Since Robolectric 4.9.1, these are available
+      it.systemProperty("robolectric.dependency.proxy.host", project.findProperty("systemProp.https.proxyHost") ?: System.getenv("ROBOLECTRIC_PROXY_HOST"))
+      it.systemProperty("robolectric.dependency.proxy.port", project.findProperty("systemProp.https.proxyPort") ?: System.getenv("ROBOLECTRIC_PROXY_PORT"))
     }
-    ```
+  }
+}
+```
+///
 
 ## `ConscryptMode`
 

--- a/docs/device-configuration.md
+++ b/docs/device-configuration.md
@@ -9,23 +9,23 @@ the test method, test class, package, or suite level, as described [here](config
 The Android device configuration can be specified using the [`qualifiers`][config-qualifiers]
 [`@Config`][config-documentation] argument:
 
-=== "Java"
+/// tab | Java
+```java
+@Test
+@Config(qualifiers = "fr-rFR-w360dp-h640dp-xhdpi")
+public void testItOnFrenchNexus5() {
+}
+```
+///
 
-    ```java
-    @Test
-    @Config(qualifiers = "fr-rFR-w360dp-h640dp-xhdpi")
-    public void testItOnFrenchNexus5() {
-    }
-    ```
-
-=== "Kotlin"
-
-    ```kotlin
-    @Test
-    @Config(qualifiers = "fr-rFR-w360dp-h640dp-xhdpi")
-    fun testItOnFrenchNexus5() {
-    }
-    ```
+/// tab | Kotlin
+```kotlin
+@Test
+@Config(qualifiers = "fr-rFR-w360dp-h640dp-xhdpi")
+fun testItOnFrenchNexus5() {
+}
+```
+///
 
 From [version 3.6][robolectric-3.6-release] on, Robolectric parses the `qualifiers` property
 according to the rules set forth [here][android-resources-qualifier-rules] (but with no preceding
@@ -68,53 +68,53 @@ example, qualifiers at the test method level occlude qualifiers at the test clas
 the qualifiers config property starts with a `+` (plus sign), it is interpreted as an overlay to any
 higher-level qualifiers that have been specified:
 
-=== "Java"
+/// tab | Java
+```java
+@Config(qualifiers = "xlarge-port")
+public class MyTest {
+  @Test
+  public void testItWithXlargePort() {
+    // Config is "xlarge-port"
+  }
 
-    ```java
-    @Config(qualifiers = "xlarge-port")
-    public class MyTest {
-      @Test
-      public void testItWithXlargePort() {
-        // Config is "xlarge-port"
-      }
+  @Test
+  @Config(qualifiers = "+land")
+  public void testItWithXlargeLand() {
+    // Config is "xlarge-land"
+  }
 
-      @Test
-      @Config(qualifiers = "+land")
-      public void testItWithXlargeLand() {
-        // Config is "xlarge-land"
-      }
+  @Test
+  @Config(qualifiers = "land")
+  public void testItWithLand() {
+    // Config is "normal-land"
+  }
+}
+```
+///
 
-      @Test
-      @Config(qualifiers = "land")
-      public void testItWithLand() {
-        // Config is "normal-land"
-      }
-    }
-    ```
+/// tab | Kotlin
+```kotlin
+@Config(qualifiers = "xlarge-port")
+class MyTest {
+  @Test
+  fun testItWithXlargePort() {
+    // Config is "xlarge-port"
+  }
 
-=== "Kotlin"
+  @Test
+  @Config(qualifiers = "+land")
+  fun testItWithXlargeLand() {
+    // Config is "xlarge-land"
+  }
 
-    ```kotlin
-    @Config(qualifiers = "xlarge-port")
-    class MyTest {
-      @Test
-      fun testItWithXlargePort() {
-        // Config is "xlarge-port"
-      }
-
-      @Test
-      @Config(qualifiers = "+land")
-      fun testItWithXlargeLand() {
-        // Config is "xlarge-land"
-      }
-
-      @Test
-      @Config(qualifiers = "land")
-      fun testItWithLand() {
-        // Config is "normal-land"
-      }
-    }
-    ```
+  @Test
+  @Config(qualifiers = "land")
+  fun testItWithLand() {
+    // Config is "normal-land"
+  }
+}
+```
+///
 
 Values for unspecified properties are calculated, and rules are applied, after all configs have been
 merged.
@@ -124,35 +124,35 @@ merged.
 The device configuration can be changed within a test using
 [`RuntimeEnvironment.setQualifiers()`][runtime-environment-set-qualifiers]:
 
-=== "Java"
+/// tab | Java
+```java
+@Test
+@Config(qualifiers = "+port")
+public void testOrientationChange() {
+  MyActivity controller = Robolectric.buildActivity(MyActivity.class);
+  controller.setup();
+  // assert that activity is in portrait mode
+  RuntimeEnvironment.setQualifiers("+land");
+  controller.configurationChange();
+  // assert that activity is in landscape mode
+}
+```
+///
 
-    ```java
-    @Test
-    @Config(qualifiers = "+port")
-    public void testOrientationChange() {
-      MyActivity controller = Robolectric.buildActivity(MyActivity.class);
-      controller.setup();
-      // assert that activity is in portrait mode
-      RuntimeEnvironment.setQualifiers("+land");
-      controller.configurationChange();
-      // assert that activity is in landscape mode
-    }
-    ```
-
-=== "Kotlin"
-
-    ```kotlin
-    @Test
-    @Config(qualifiers = "+port")
-    fun testOrientationChange() {
-      val controller = Robolectric.buildActivity(MyActivity.class)
-      controller.setup()
-      // assert that activity is in portrait mode
-      RuntimeEnvironment.setQualifiers("+land")
-      controller.configurationChange()
-      // assert that activity is in landscape mode
-    }
-    ```
+/// tab | Kotlin
+```kotlin
+@Test
+@Config(qualifiers = "+port")
+fun testOrientationChange() {
+  val controller = Robolectric.buildActivity(MyActivity::class)
+  controller.setup()
+  // assert that activity is in portrait mode
+  RuntimeEnvironment.setQualifiers("+land")
+  controller.configurationChange()
+  // assert that activity is in landscape mode
+}
+```
+///
 
 The string parameter to `RuntimeEnvironment.setQualifiers()` has the same rules as
 `Config.qualifiers`.

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -33,20 +33,20 @@ Shadow classes should mimic the production classes' inheritance hierarchy. For e
 implementing a Shadow for [`ViewGroup`][view-group-documentation], `ShadowViewGroup`, then your
 Shadow class should extend `ViewGroup`'s superclass' Shadow, `ShadowView`.
 
-=== "Java"
+/// tab | Java
+```java
+@Implements(ViewGroup.class)
+public class ShadowViewGroup extends ShadowView {
+}
+```
+///
 
-    ```java
-    @Implements(ViewGroup.class)
-    public class ShadowViewGroup extends ShadowView {
-    }
-    ```
-
-=== "Kotlin"
-
-    ```kotlin
-    @Implements(ViewGroup::class)
-    class ShadowViewGroup : ShadowView
-    ```
+/// tab | Kotlin
+```kotlin
+@Implements(ViewGroup::class)
+class ShadowViewGroup : ShadowView
+```
+///
 
 ## Methods
 
@@ -56,17 +56,17 @@ Android object is invoked.
 
 Suppose an application defined the following line of code:
 
-=== "Java"
+/// tab | Java
+```java
+imageView.setImageResource(R.drawable.robolectric_logo);
+```
+///
 
-    ```java
-    imageView.setImageResource(R.drawable.robolectric_logo);
-    ```
-
-=== "Kotlin"
-
-    ```kotlin
-    imageView.setImageResource(R.drawable.robolectric_logo)
-    ```
+/// tab | Kotlin
+```kotlin
+imageView.setImageResource(R.drawable.robolectric_logo)
+```
+///
 
 Under test, the `ShadowImageView#setImageResource(int resId)` method on the Shadow instance would be
 invoked.
@@ -74,29 +74,29 @@ invoked.
 Shadow methods must be marked with the [`@Implementation`][implementation-documentation] annotation.
 Robolectric includes a lint test to help ensure this is done correctly.
 
-=== "Java"
+/// tab | Java
+```java
+@Implements(ImageView.class)
+public class ShadowImageView extends ShadowView {
+  @Implementation
+  protected void setImageResource(int resId) {
+    // Implementation goes here
+  }
+}
+```
+///
 
-    ```java
-    @Implements(ImageView.class)
-    public class ShadowImageView extends ShadowView {
-      @Implementation
-      protected void setImageResource(int resId) {
-        // Implementation goes here
-      }
-    }
-    ```
-
-=== "Kotlin"
-
-    ```kotlin
-    @Implements(ImageView::class)
-    class ShadowImageView : ShadowView {
-      @Implementation
-      protected fun setImageResource(resId: Int) {
-        // Implementation goes here
-      }
-    }
-    ```
+/// tab | Kotlin
+```kotlin
+@Implements(ImageView::class)
+class ShadowImageView : ShadowView {
+  @Implementation
+  protected fun setImageResource(resId: Int) {
+    // Implementation goes here
+  }
+}
+```
+///
 
 Robolectric supports shadowing all methods on the original class, including `private`, `static`,
 `final` or `native`.
@@ -121,41 +121,42 @@ invoked on the real object.
 For instance, if the application code was to invoke the [`TextView`][text-view-documentation]
 constructor which receives a [`Context`][context-documentation]:
 
-=== "Java"
+/// tab | Java
+```java
+new TextView(context);
+```
+///
 
-    ```java
-    new TextView(context);
-    ```
-
-=== "Kotlin"
-
-    ```kotlin
-    TextView(context)
-    ```
+/// tab | Kotlin
+```kotlin
+TextView(context)
+```
+///
 
 Robolectric would invoke the following  `__constructor__` method that receives a `Context`:
 
-=== "Java"
+/// tab | Java
+```java
+@Implements(TextView.class)
+public class ShadowTextView {
+  @Implementation
+  protected void __constructor__(Context context) {
+    this.context = context;
+  }
+}
+```
+///
 
-    ```java
-    @Implements(TextView.class)
-    public class ShadowTextView {
-      @Implementation
-      protected void __constructor__(Context context) {
-        this.context = context;
-      }
-    ```
-
-=== "Kotlin"
-
-    ```kotlin
-    @Implements(TextView::class)
-    class ShadowTextView {
-      @Implementation
-      protected fun __constructor__(context: Context) {
-        this.context = context
-      }
-    ```
+/// tab | Kotlin
+```kotlin
+@Implements(TextView::class)
+class ShadowTextView {
+  @Implementation
+  protected fun __constructor__(context: Context) {
+    this.context = context
+  }
+```
+///
 
 ## Getting access to the real instance
 
@@ -163,33 +164,33 @@ Sometimes Shadow classes may want to refer to the object they are shadowing, e.g
 fields. A Shadow class can achieve this by declaring a field annotated with
 [`@RealObject`][real-object-documentation]:
 
-=== "Java"
+/// tab | Java
+```java
+@Implements(Point.class)
+public class ShadowPoint {
+  @RealObject private Point realPoint;
 
-    ```java
-    @Implements(Point.class)
-    public class ShadowPoint {
-      @RealObject private Point realPoint;
+  public void __constructor__(int x, int y) {
+    realPoint.x = x;
+    realPoint.y = y;
+  }
+}
+```
+///
 
-      public void __constructor__(int x, int y) {
-        realPoint.x = x;
-        realPoint.y = y;
-      }
-    }
-    ```
+/// tab | Kotlin
+```kotlin
+@Implements(Point::class)
+class ShadowPoint {
+  @RealObject private lateinit var realPoint: Point
 
-=== "Kotlin"
-
-    ```kotlin
-    @Implements(Point::class)
-    class ShadowPoint {
-      @RealObject private lateinit var realPoint: Point
-
-      fun __constructor__(x: Int, y: Int) {
-        realPoint.x = x
-        realPoint.y = y
-      }
-    }
-    ```
+  fun __constructor__(x: Int, y: Int) {
+    realPoint.x = x
+    realPoint.y = y
+  }
+}
+```
+///
 
 Robolectric will set `realPoint` to the actual instance of [`Point`][point-documentation] before
 invoking any other methods.
@@ -220,45 +221,45 @@ options, such as shadowing instance methods using `@Implementation` or shadowing
 `__constructor__()` methods. Your shadow class may also extend one of the stock Robolectric shadows
 if you like.
 
-=== "Java"
+/// tab | Java
+```java
+@Implements(Bitmap.class)
+public class MyShadowBitmap {
+  @RealObject private Bitmap realBitmap;
+  private int bitmapQuality = -1;
 
-    ```java
-    @Implements(Bitmap.class)
-    public class MyShadowBitmap {
-      @RealObject private Bitmap realBitmap;
-      private int bitmapQuality = -1;
+  @Implementation
+  public boolean compress(Bitmap.CompressFormat format, int quality, OutputStream stream) {
+    bitmapQuality = quality;
+    return realBitmap.compress(format, quality, stream);
+  }
 
-      @Implementation
-      public boolean compress(Bitmap.CompressFormat format, int quality, OutputStream stream) {
-        bitmapQuality = quality;
-        return realBitmap.compress(format, quality, stream);
-      }
+  public int getQuality() {
+    return bitmapQuality;
+  }
+}
+```
+///
 
-      public int getQuality() {
-        return bitmapQuality;
-      }
-    }
-    ```
+/// tab | Kotlin
+```kotlin
+@Implements(Bitmap::class)
+class MyShadowBitmap {
+  @RealObject private lateinit var realBitmap: Bitmap
+  private var bitmapQuality: Int = -1
 
-=== "Kotlin"
+  @Implementation
+  fun compress(format: Bitmap.CompressFormat, quality: Int, stream: OutputStream): Boolean {
+    bitmapQuality = quality
+    return realBitmap.compress(format, quality, stream)
+  }
 
-    ```kotlin
-    @Implements(Bitmap::class)
-    class MyShadowBitmap {
-      @RealObject private lateinit var realBitmap: Bitmap
-      private var bitmapQuality: Int = -1;
-
-      @Implementation
-      fun compress(format: Bitmap.CompressFormat, quality: Int, stream: OutputStream): Boolean {
-        bitmapQuality = quality
-        return realBitmap.compress(format, quality, stream)
-      }
-
-      fun getQuality(): Int {
-        return bitmapQuality
-      }
-    }
-    ```
+  fun getQuality(): Int {
+    return bitmapQuality
+  }
+}
+```
+///
 
 ### Using a Custom Shadows
 
@@ -288,44 +289,44 @@ shadow annotation processor on your library of shadows. This provides a number o
    reset static state.
 4. Perform additional validation and checking on your shadows.
 
-=== "Groovy"
-
-    ```groovy
-    android {
-      defaultConfig {
-        javaCompileOptions {
-          annotationProcessorOptions {
-            className 'org.robolectric.annotation.processing.RobolectricProcessor'
-            arguments = [ 'org.robolectric.annotation.processing.shadowPackage': 'com.example.myshadowpackage' ]
-          }
-        }
+/// tab | Groovy
+```groovy
+android {
+  defaultConfig {
+    javaCompileOptions {
+      annotationProcessorOptions {
+        className 'org.robolectric.annotation.processing.RobolectricProcessor'
+        arguments = ['org.robolectric.annotation.processing.shadowPackage': 'com.example.myshadowpackage']
       }
     }
+  }
+}
 
-    dependencies {
-      annotationProcessor 'org.robolectric:processor:{{ robolectric.version.current }}'
-    }
-    ```
+dependencies {
+  annotationProcessor 'org.robolectric:processor:{{ robolectric.version.current }}'
+}
+```
+///
 
-=== "Kotlin"
+/// tab | Kotlin
+When you write your shadows in Kotlin, configure [`kapt`][kapt-documentation]:
 
-    When you write your shadows in Kotlin, configure [`kapt`][kapt-documentation]:
+```kotlin
+plugins {
+  id("kotlin-kapt")
+}
 
-    ```kotlin
-    plugins {
-      id("kotlin-kapt")
-    }
+kapt {
+  arguments {
+    arg("org.robolectric.annotation.processing.shadowPackage", "com.example.myshadowpackage")
+  }
+}
 
-    kapt {
-      arguments {
-        arg("org.robolectric.annotation.processing.shadowPackage", "com.example.myshadowpackage")
-      }
-    }
-
-    dependencies {
-      kapt("org.robolectric:processor:{{ robolectric.version.current }}")
-    }
-    ```
+dependencies {
+  kapt("org.robolectric:processor:{{ robolectric.version.current }}")
+}
+```
+///
 
 ## Best practices
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,60 +8,60 @@ for Android.
 
 Start by adding the following to your module's `build.gradle`/`build.gradle.kts` file:
 
-=== "Groovy"
-
-    ```groovy
-    android {
-      testOptions {
-        unitTests {
-          includeAndroidResources = true
-        }
-      }
+/// tab | Groovy
+```groovy
+android {
+  testOptions {
+    unitTests {
+      includeAndroidResources = true
     }
+  }
+}
 
-    dependencies {
-      testImplementation 'junit:junit:4.13.2'
-      testImplementation 'org.robolectric:robolectric:{{ robolectric.version.current }}'
+dependencies {
+  testImplementation 'junit:junit:4.13.2'
+  testImplementation 'org.robolectric:robolectric:{{ robolectric.version.current }}'
+}
+```
+///
+
+/// tab | Kotlin
+```kotlin
+android {
+  testOptions {
+    unitTests {
+      isIncludeAndroidResources = true
     }
-    ```
+  }
+}
 
-=== "Kotlin"
-
-    ```kotlin
-    android {
-      testOptions {
-        unitTests {
-          isIncludeAndroidResources = true
-        }
-      }
-    }
-
-    dependencies {
-      testImplementation("junit:junit:4.13.2")
-      testImplementation("org.robolectric:robolectric:{{ robolectric.version.current }}")
-    }
-    ```
+dependencies {
+  testImplementation("junit:junit:4.13.2")
+  testImplementation("org.robolectric:robolectric:{{ robolectric.version.current }}")
+}
+```
+///
 
 Then, mark your test to run with `RobolectricTestRunner`:
 
-=== "Java"
+/// tab | Java
+```java
+import org.robolectric.RobolectricTestRunner;
 
-    ```java
-    import org.robolectric.RobolectricTestRunner;
+@RunWith(RobolectricTestRunner.class)
+public class SandwichTest {
+}
+```
+///
 
-    @RunWith(RobolectricTestRunner.class)
-    public class SandwichTest {
-    }
-    ```
+/// tab | Kotlin
+```kotlin
+import org.robolectric.RobolectricTestRunner
 
-=== "Kotlin"
-
-    ```kotlin
-    import org.robolectric.RobolectricTestRunner
-
-    @RunWith(RobolectricTestRunner::class)
-    class SandwichTest
-    ```
+@RunWith(RobolectricTestRunner::class)
+class SandwichTest
+```
+///
 
 ## Building with Bazel
 
@@ -142,24 +142,24 @@ Start by adding the following to your module's `pom.xml` file:
 
 Then, mark your test to run with `RobolectricTestRunner`:
 
-=== "Java"
+/// tab | Java
+```java
+import org.robolectric.RobolectricTestRunner;
 
-    ```java
-    import org.robolectric.RobolectricTestRunner;
+@RunWith(RobolectricTestRunner.class)
+public class SandwichTest {
+}
+```
+///
 
-    @RunWith(RobolectricTestRunner.class)
-    public class SandwichTest {
-    }
-    ```
+/// tab | Kotlin
+```kotlin
+import org.robolectric.RobolectricTestRunner
 
-=== "Kotlin"
-
-    ```kotlin
-    import org.robolectric.RobolectricTestRunner
-
-    @RunWith(RobolectricTestRunner::class)
-    class SandwichTest
-    ```
+@RunWith(RobolectricTestRunner::class)
+class SandwichTest
+```
+///
 
 ### Using libraries
 
@@ -167,32 +167,32 @@ If you use Maven to build your application, you will need to tell Robolectric wh
 resources are located for each library you use. This can either be specified with the `@Config`
 annotation:
 
-=== "Java"
+/// tab | Java
+```java
+import org.robolectric.RobolectricTestRunner;
 
-    ```java
-    import org.robolectric.RobolectricTestRunner;
+@RunWith(RobolectricTestRunner.class)
+@Config(libraries = {
+  "build/unpacked-libraries/library1",
+  "build/unpacked-libraries/library2"
+})
+public class SandwichTest {
+}
+```
+///
 
-    @RunWith(RobolectricTestRunner.class)
-    @Config(libraries = {
-        "build/unpacked-libraries/library1",
-        "build/unpacked-libraries/library2"
-    })
-    public class SandwichTest {
-    }
-    ```
+/// tab | Kotlin
+```kotlin
+import org.robolectric.RobolectricTestRunner
 
-=== "Kotlin"
-
-    ```kotlin
-    import org.robolectric.RobolectricTestRunner
-
-    @RunWith(RobolectricTestRunner::class)
-    @Config(libraries = [
-        "build/unpacked-libraries/library1",
-        "build/unpacked-libraries/library2"
-    ])
-    class SandwichTest
-    ```
+@RunWith(RobolectricTestRunner::class)
+@Config(libraries = [
+  "build/unpacked-libraries/library1",
+  "build/unpacked-libraries/library2"
+])
+class SandwichTest
+```
+///
 
 or specified in the [`robolectric.properties`](configuring.md/#robolectricproperties-file) file:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,29 +17,29 @@ often take minutes. That's no way to do <abbr title="Test-Driven Development">TD
 be a better way. Robolectric is a framework that brings fast and reliable unit tests to Android.
 Tests run inside the JVM in seconds. With Robolectric you can write tests like this:
 
-=== "Java"
+/// tab | Java
+```java
+--8<-- "snippets/java/src/test/java/org/robolectric/snippets/java/MyActivityTest.java:index_sample_test"
+```
+///
 
-    ```java
-    --8<-- "snippets/java/src/test/java/org/robolectric/snippets/java/MyActivityTest.java:index_sample_test"
-    ```
+/// tab | Kotlin
+```kotlin
+@RunWith(RobolectricTestRunner::class)
+class MyActivityTest {
+  @Test
+  fun clickingButton_shouldChangeMessage() {
+    Robolectric.buildActivity(MyActivity::class).use { controller ->
+      controller.setup() // Moves the Activity to the RESUMED state
+      val activity = controller.get()
 
-=== "Kotlin"
-
-    ```kotlin
-    @RunWith(RobolectricTestRunner::class)
-    class MyActivityTest {
-      @Test
-      fun clickingButton_shouldChangeMessage() {
-        Robolectric.buildActivity(MyActivity::class).use { controller ->
-          controller.setup() // Moves the Activity to the RESUMED state
-          val activity = controller.get()
-
-          activity.findViewById(R.id.button).performClick()
-          assertEquals((activity.findViewById(R.id.text) as TextView).text, "Robolectric Rocks!")
-        }
-      }
+      activity.findViewById(R.id.button).performClick()
+      assertEquals((activity.findViewById(R.id.text) as TextView).text, "Robolectric Rocks!")
     }
-    ```
+  }
+}
+```
+///
 
 [Get started](getting-started.md){ .md-button .md-button--primary }
 

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -15,23 +15,23 @@ Robolectric 4.0 requires Android Gradle Plugin 3.2 or greater.
 
 Update the configuration in your module's `build.gradle`/`build.gradle.kts` file:
 
-=== "Groovy"
+/// tab | Groovy
+```groovy
+android {
+  compileSdkVersion 28 // Or newer
+  testOptions.unitTests.includeAndroidResources = true
+}
+```
+///
 
-    ```groovy
-    android {
-        compileSdkVersion 28 // Or newer
-        testOptions.unitTests.includeAndroidResources = true
-    }
-    ```
-
-=== "Kotlin"
-
-    ```kotlin
-    android {
-        compileSdkVersion = 28 // Or newer
-        testOptions.unitTests.isIncludeAndroidResources = true
-    }
-    ```
+/// tab | Kotlin
+```kotlin
+android {
+  compileSdkVersion = 28 // Or newer
+  testOptions.unitTests.isIncludeAndroidResources = true
+}
+```
+///
 
 Add the following in your `gradle.properties` file:
 
@@ -237,20 +237,20 @@ possible.
 Replace subclasses of `DefaultPackageManager` by a custom shadow (and be a good citizen by
 contributing your enhancements upstream 🙂):
 
-=== "Java"
+/// tab | Java
+```java
+@Implements(value = ApplicationPackageManager.class, inheritImplementationMethods = true)
+public class MyCustomPackageManager extends ShadowApplicationPackageManager {
+}
+```
+///
 
-    ```java
-    @Implements(value = ApplicationPackageManager.class, inheritImplementationMethods = true)
-    public class MyCustomPackageManager extends ShadowApplicationPackageManager {
-    }
-    ```
-
-=== "Kotlin"
-
-    ```kotlin
-    @Implements(value = ApplicationPackageManager::class, inheritImplementationMethods = true)
-    class MyCustomPackageManager : ShadowApplicationPackageManager
-    ```
+/// tab | Kotlin
+```kotlin
+@Implements(value = ApplicationPackageManager::class, inheritImplementationMethods = true)
+class MyCustomPackageManager : ShadowApplicationPackageManager
+```
+///
 
 If you are using a custom subclass of `DefaultPackageManager` to implement functionality missing in
 Robolectric, check again as part of this work we've added support for a bunch more widely-used
@@ -298,51 +298,51 @@ you probably actually want to do is override
 
 #### Old code
 
-=== "Java"
+/// tab | Java
+```java
+public class MyTestRunner extends RobolectricTestRunner {
+  @Override protected Properties getConfigProperties() {
+    Properties props = new Properties();
+    props.setProperty("sdk", "23");
+    return props;
+  }
+}
+```
+///
 
-    ```java
-    public class MyTestRunner extends RobolectricTestRunner {
-      @Override protected Properties getConfigProperties() {
-        Properties props = new Properties();
-        props.setProperty("sdk", "23");
-        return props;
-      }
-    }
-    ```
-
-=== "Kotlin"
-
-    ```kotlin
-    class MyTestRunner : RobolectricTestRunner {
-      override protected fun getConfigProperties(): Properties {
-        val props = Properties()
-        props.setProperty("sdk", "23")
-        return props
-      }
-    }
-    ```
+/// tab | Kotlin
+```kotlin
+class MyTestRunner : RobolectricTestRunner {
+  override protected fun getConfigProperties(): Properties {
+    val props = Properties()
+    props.setProperty("sdk", "23")
+    return props
+  }
+}
+```
+///
 
 #### New code
 
-=== "Java"
+/// tab | Java
+```java
+public class MyTestRunner extends RobolectricTestRunner {
+  @Override protected Config buildGlobalConfig() {
+    return new Config.Builder().setSdk(23).build();
+  }
+}
+```
+///
 
-    ```java
-    public class MyTestRunner extends RobolectricTestRunner {
-      @Override protected Config buildGlobalConfig() {
-        return new Config.Builder().setSdk(23).build();
-      }
-    }
-    ```
-
-=== "Kotlin"
-
-    ```kotlin
-    class MyTestRunner : RobolectricTestRunner {
-      override protected buildGlobalConfig(): Config {
-        return Config.Builder().setSdk(23).build()
-      }
-    }
-    ```
+/// tab | Kotlin
+```kotlin
+class MyTestRunner : RobolectricTestRunner {
+  override protected fun buildGlobalConfig(): Config {
+    return Config.Builder().setSdk(23).build()
+  }
+}
+```
+///
 
 ### Package-Level Configuration
 
@@ -372,19 +372,19 @@ configure all tests, the expected location of the file has been changed.
   `Context` and [`ContextWrapper`][context-wrapper-documentation] in favor of using real framework
   code to improve fidelity.
 
-=== "Java"
+/// tab | Java
+```java
+Robolectric.buildService(MyService.class).create().get();
+Robolectric.setupContentProvider(MyContentProvider.class);
+```
+///
 
-    ```java
-    Robolectric.buildService(MyService.class).create().get();
-    Robolectric.setupContentProvider(MyContentProvider.class);
-    ```
-
-=== "Kotlin"
-
-    ```kotlin
-    Robolectric.buildService(MyService::class).create().get()
-    Robolectric.setupContentProvider(MyContentProvider::class)
-    ```
+/// tab | Kotlin
+```kotlin
+Robolectric.buildService(MyService::class).create().get()
+Robolectric.setupContentProvider(MyContentProvider::class)
+```
+///
 
 * We've removed shadow methods where they duplicate the functionality of the Android APIs. In
   general, prefer calling Android framework APIs over Robolectric shadows where possible.
@@ -429,19 +429,19 @@ configure all tests, the expected location of the file has been changed.
 * Support for API 21 (Lollipop)
 * Custom test runner for Gradle / Android Studio:
 
-=== "Java"
+/// tab | Java
+```java
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
+```
+///
 
-    ```java
-    @RunWith(RobolectricGradleTestRunner.class)
-    @Config(constants = BuildConfig.class)
-    ```
-
-=== "Kotlin"
-
-    ```kotlin
-    @RunWith(RobolectricGradleTestRunner::class)
-    @Config(constants = BuildConfig::class)
-    ```
+/// tab | Kotlin
+```kotlin
+@RunWith(RobolectricGradleTestRunner::class)
+@Config(constants = BuildConfig::class)
+```
+///
 
 ### Major Changes
 
@@ -482,17 +482,17 @@ configure all tests, the expected location of the file has been changed.
 
 Main "core" module for Robolectric 3.0.
 
-=== "Groovy"
+/// tab | Groovy
+```groovy
+testCompile 'org.robolectric:robolectric:3.0'
+```
+///
 
-    ```groovy
-    testCompile 'org.robolectric:robolectric:3.0'
-    ```
-
-=== "Kotlin"
-
-    ```kotlin
-    testCompile("org.robolectric:robolectric:3.0")
-    ```
+/// tab | Kotlin
+```kotlin
+testCompile("org.robolectric:robolectric:3.0")
+```
+///
 
 Some of the shadows in Robolectric have been split out into separate modules to reduce the number of
 transitive dependencies imposed on projects using Robolectric. If you want to use any of these
@@ -502,17 +502,17 @@ shadows, add the needed artifacts below to your build.
 
 Shadows for classes in the Android `support-v4` library.
 
-=== "Groovy"
+/// tab | Groovy
+```groovy
+testCompile 'org.robolectric:shadows-support-v4:3.0'
+```
+///
 
-    ```groovy
-    testCompile 'org.robolectric:shadows-support-v4:3.0'
-    ```
-
-=== "Kotlin"
-
-    ```kotlin
-    testCompile("org.robolectric:shadows-support-v4:3.0")
-    ```
+/// tab | Kotlin
+```kotlin
+testCompile("org.robolectric:shadows-support-v4:3.0")
+```
+///
 
 #### `org.robolectric:shadows-httpclient`
   
@@ -520,33 +520,33 @@ Shadows for classes in Apache HTTP client. This includes methods like
 `Robolectric.getLatestSentHttpRequest`. These methods have moved to
 [`FakeHttp.getLatestSentHttpRequest`][fake-http-get-latest-sent-http-request-javadoc].
 
-=== "Groovy"
+/// tab | Groovy
+```groovy
+testCompile 'org.robolectric:shadows-httpclient:3.0'
+```
+///
 
-    ```groovy
-    testCompile 'org.robolectric:shadows-httpclient:3.0'
-    ```
-
-=== "Kotlin"
-
-    ```kotlin
-    testCompile("org.robolectric:shadows-httpclient:3.0")
-    ```
+/// tab | Kotlin
+```kotlin
+testCompile("org.robolectric:shadows-httpclient:3.0")
+```
+///
 
 #### `org.robolectric:shadows-maps`
 
 Shadows for classes in Google Maps.
 
-=== "Groovy"
+/// tab | Groovy
+```groovy
+testCompile 'org.robolectric:shadows-maps:3.0'
+```
+///
 
-    ```groovy
-    testCompile 'org.robolectric:shadows-maps:3.0'
-    ```
-
-=== "Kotlin"
-
-    ```kotlin
-    testCompile("org.robolectric:shadows-maps:3.0")
-    ```
+/// tab | Kotlin
+```kotlin
+testCompile("org.robolectric:shadows-maps:3.0")
+```
+///
 
 [activity-controller-javadoc]: javadoc/latest/org/robolectric/android/controller/ActivityController.html
 [activity-documentation]: https://developer.android.com/reference/android/app/Activity

--- a/docs/using-qualifiers.md
+++ b/docs/using-qualifiers.md
@@ -19,54 +19,54 @@ you would like to change the resource qualifiers for the whole file, or simply o
 
 Given the following resources:
 
-=== "`values/strings.xml`"
+/// tab | `values/strings.xml`
+```xml
+<string name="not_overridden">Not overridden</string>
+<string name="overridden">Overridden</string>
+<string name="overridden_twice">Overridden twice</string>
+```
+///
 
-    ```xml
-    <string name="not_overridden">Not overridden</string>
-    <string name="overridden">Overridden</string>
-    <string name="overridden_twice">Overridden twice</string>
-    ```
+/// tab | `values-en/strings.xml`
+```xml
+<string name="overridden">Overridden in en</string>
+<string name="overridden_twice">Overridden twice in en</string>
+```
+///
 
-=== "`values-en/strings.xml`"
-
-    ```xml
-    <string name="overridden">Overridden in en</string>
-    <string name="overridden_twice">Overridden twice in en</string>
-    ```
-
-=== "`values-en-port/strings.xml`"
-
-    ```xml
-    <string name="overridden_twice">Overridden twice in en-port</string>
-    ```
+/// tab | `values-en-port/strings.xml`
+```xml
+<string name="overridden_twice">Overridden twice in en-port</string>
+```
+///
 
 this Robolectric test would pass, using the Android resource qualifier resolution rules:
 
-=== "Java"
+/// tab | Java
+```java
+@Test
+@Config(qualifiers = "en-port")
+public void shouldUseEnglishAndPortraitResources() {
+  final Context context = RuntimeEnvironment.application;
+  assertThat(context.getString(R.id.not_overridden)).isEqualTo("Not overridden");
+  assertThat(context.getString(R.id.overridden)).isEqualTo("Overridden in en");
+  assertThat(context.getString(R.id.overridden_twice)).isEqualTo("Overridden twice in en-port");
+}
+```
+///
 
-    ```java
-    @Test
-    @Config(qualifiers = "en-port")
-    public void shouldUseEnglishAndPortraitResources() {
-      final Context context = RuntimeEnvironment.application;
-      assertThat(context.getString(R.id.not_overridden)).isEqualTo("Not overridden");
-      assertThat(context.getString(R.id.overridden)).isEqualTo("Overridden in en");
-      assertThat(context.getString(R.id.overridden_twice)).isEqualTo("Overridden twice in en-port");
-    }
-    ```
-
-=== "Kotlin"
-
-    ```kotlin
-    @Test
-    @Config(qualifiers = "en-port")
-    fun shouldUseEnglishAndPortraitResources() {
-      val context = RuntimeEnvironment.application
-      assertThat(context.getString(R.id.not_overridden)).isEqualTo("Not overridden")
-      assertThat(context.getString(R.id.overridden)).isEqualTo("Overridden in en")
-      assertThat(context.getString(R.id.overridden_twice)).isEqualTo("Overridden twice in en-port")
-    }
-    ```
+/// tab | Kotlin
+```kotlin
+@Test
+@Config(qualifiers = "en-port")
+fun shouldUseEnglishAndPortraitResources() {
+    val context = RuntimeEnvironment.application
+    assertThat(context.getString(R.id.not_overridden)).isEqualTo("Not overridden")
+    assertThat(context.getString(R.id.overridden)).isEqualTo("Overridden in en")
+    assertThat(context.getString(R.id.overridden_twice)).isEqualTo("Overridden twice in en-port")
+}
+```
+///
 
 Multiple qualifiers should be separated by dashes and provided in the order put forth in
 [this list][android-resources-qualifiers-order].

--- a/docs/writing-a-test.md
+++ b/docs/writing-a-test.md
@@ -7,38 +7,38 @@ hide:
 
 Let's say that you have an [`Activity`][activity-documentation] that represents a welcome screen:
 
-=== "Java"
+/// tab | Java
+```java
+public class WelcomeActivity extends Activity {
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.welcome_activity);
 
-    ```java
-    public class WelcomeActivity extends Activity {
-        @Override
-        protected void onCreate(@Nullable Bundle savedInstanceState) {
-            super.onCreate(savedInstanceState);
-            setContentView(R.layout.welcome_activity);
-    
-            final Button button = findViewById(R.id.login);
-            button.setOnClickListener((view) -> {
-                startActivity(new Intent(WelcomeActivity.this, LoginActivity.class))
-            });
+        final Button button = findViewById(R.id.login);
+        button.setOnClickListener((view) -> {
+            startActivity(new Intent(WelcomeActivity.this, LoginActivity.class))
+        });
+    }
+}
+```
+///
+
+/// tab | Kotlin
+```kotlin
+class WelcomeActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.welcome_activity)
+
+        val button = findViewById<Button>(R.id.login)
+        button.setOnClickListener {
+            startActivity(Intent(this, LoginActivity::class.java))
         }
     }
-    ```
-
-=== "Kotlin"
-
-    ```kotlin
-    class WelcomeActivity : Activity() {
-        override fun onCreate(savedInstanceState: Bundle?) {
-            super.onCreate(savedInstanceState)
-            setContentView(R.layout.welcome_activity)
-    
-            val button = findViewById<Button>(R.id.login)
-            button.setOnClickListener {
-                startActivity(Intent(this, LoginActivity::class.java))
-            }
-        }
-    }
-    ```
+}
+```
+///
 
 ```xml title="welcome_activity.xml"
 <?xml version="1.0" encoding="utf-8"?>
@@ -62,47 +62,47 @@ To achieve this, we can check that the correct [`Intent`][intent-documentation] 
 click is performed. Since Robolectric is a unit testing framework, the `LoginActivity` will not
 actually be started.
 
-=== "Java"
+/// tab | Java
+```java
+@RunWith(RobolectricTestRunner.class)
+public class WelcomeActivityTest {
+    @Test
+    public void clickingLogin_shouldStartLoginActivity() {
+        try (ActivityController<WelcomeActivity> controller = Robolectric.buildActivity(WelcomeActivity.class)) {
+            controller.setup(); // Moves the Activity to the RESUMED state
 
-    ```java
-    @RunWith(RobolectricTestRunner.class)
-    public class WelcomeActivityTest {
-        @Test
-        public void clickingLogin_shouldStartLoginActivity() {
-            try (ActivityController<WelcomeActivity> controller = Robolectric.buildActivity(WelcomeActivity.class)) {
-                controller.setup(); // Moves the Activity to the RESUMED state
+            WelcomeActivity activity = controller.get();
+            activity.findViewById<Button>(R.id.login).performClick();
 
-                WelcomeActivity activity = controller.get();
-                activity.findViewById<Button>(R.id.login).performClick();
-    
-                Intent expectedIntent = new Intent(activity, LoginActivity.class);
-                Intent actual = shadowOf(RuntimeEnvironment.application).getNextStartedActivity();
-                assertEquals(expectedIntent.getComponent(), actual.getComponent());
-            }
+            Intent expectedIntent = new Intent(activity, LoginActivity.class);
+            Intent actual = shadowOf(RuntimeEnvironment.application).getNextStartedActivity();
+            assertEquals(expectedIntent.getComponent(), actual.getComponent());
         }
     }
-    ```
+}
+```
+///
 
-=== "Kotlin"
+/// tab | Kotlin
+```kotlin
+@RunWith(RobolectricTestRunner::class)
+class WelcomeActivityTest {
+    @Test
+    fun clickingLogin_shouldStartLoginActivity() {
+        Robolectric.buildActivity(WelcomeActivity::class.java).use { controller ->
+            controller.setup() // Moves the Activity to the RESUMED state
 
-    ```kotlin
-    @RunWith(RobolectricTestRunner::class)
-    class WelcomeActivityTest {
-        @Test
-        fun clickingLogin_shouldStartLoginActivity() {
-            Robolectric.buildActivity(WelcomeActivity::class.java).use { controller ->
-                controller.setup() // Moves the Activity to the RESUMED state
+            val activity = controller.get()
+            activity.findViewById<Button>(R.id.login).performClick()
 
-                val activity = controller.get()
-                activity.findViewById<Button>(R.id.login).performClick()
-
-                val expectedIntent = Intent(activity, LoginActivity::class.java)
-                val actual = shadowOf(RuntimeEnvironment.application).nextStartedActivity
-                assertEquals(expectedIntent.component, actual.component)
-            }
+            val expectedIntent = Intent(activity, LoginActivity::class.java)
+            val actual = shadowOf(RuntimeEnvironment.application).nextStartedActivity
+            assertEquals(expectedIntent.component, actual.component)
         }
     }
-    ```
+}
+```
+///
 
 ## Test APIs
 
@@ -113,36 +113,36 @@ for tests.
 Many test APIs are extensions to individual Android classes, and can be accessed using the
 `shadowOf()` method:
 
-=== "Java"
+/// tab | Java
+```java
+// Retrieve all the toasts that have been displayed
+List<Toast> toasts = shadowOf(application).getShownToasts();
+```
+///
 
-    ```java
-    // Retrieve all the toasts that have been displayed
-    List<Toast> toasts = shadowOf(application).getShownToasts();
-    ```
-
-=== "Kotlin"
-
-    ```kotlin
-    // Retrieve all the toasts that have been displayed
-    val toasts = shadowOf(application).shownToasts
-    ```
+/// tab | Kotlin
+```kotlin
+// Retrieve all the toasts that have been displayed
+val toasts = shadowOf(application).shownToasts
+```
+///
 
 Additional test APIs are accessible as static methods on special classes called
 [shadows](extending.md), which correspond to Android framework classes:
 
-=== "Java"
+/// tab | Java
+```java
+// Simulate a new display being plugged into the device
+ShadowDisplayManager.addDisplay("xlarge-port");
+```
+///
 
-    ```java
-    // Simulate a new display being plugged into the device
-    ShadowDisplayManager.addDisplay("xlarge-port");
-    ```
-
-=== "Kotlin"
-
-    ```kotlin
-    // Simulate a new display being plugged into the device
-    ShadowDisplayManager.addDisplay("xlarge-port")
-    ```
+/// tab | Kotlin
+```kotlin
+// Simulate a new display being plugged into the device
+ShadowDisplayManager.addDisplay("xlarge-port")
+```
+///
 
 [activity-documentation]: https://developer.android.com/reference/android/app/Activity
 [intent-documentation]: https://developer.android.com/reference/android/content/Intent

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,7 +52,12 @@ markdown_extensions:
   - attr_list
   - github-callouts
   - md_in_html
-  - pymdownx.details
+  - pymdownx.blocks.tab:
+      alternate_style: true
+      combine_header_slug: true
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span
@@ -61,12 +66,6 @@ markdown_extensions:
   - pymdownx.snippets:
       url_download: true
   - pymdownx.superfences
-  - pymdownx.tabbed:
-      alternate_style: true
-      combine_header_slug: true
-      slugify: !!python/object/apply:pymdownx.slugs.slugify
-        kwds:
-          case: lower
 
 plugins:
   - blog:


### PR DESCRIPTION
The former is deprecated, and the latter is now the recommended approach.
I've also fixed a couple of language issues that I spotted in some code snippets.

The syntax between the two has changed.

## Old syntax

```markdown
=== "Tab name"

    Tab content
```

## New syntax

```markdown
/// tab | Tab name
Tab content
///
```

> [!TIP]
> You can use the "Hide whitespace changes" option to see only the actual changes, and ignore indentation changes.