### PR TITLE
Only run the `validate-snippets.yml` workflow when the `snippets` project was changed

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -1,7 +1,6 @@
 name: "Build website"
 
 on:
-  merge_group:
   pull_request:
 
 jobs:

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -1,7 +1,6 @@
 name: "Lint Markdown"
 
 on:
-  merge_group:
   pull_request:
   push:
     branches: [ master ]

--- a/.github/workflows/validate-snippets.yml
+++ b/.github/workflows/validate-snippets.yml
@@ -1,10 +1,17 @@
 name: "Validate snippets"
 
 on:
-  merge_group:
   pull_request:
+    paths:
+      - "snippets/**"
   push:
     branches: [ master ]
+    paths:
+      - "snippets/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   validate_snippets:


### PR DESCRIPTION
Changes made:
- Only run the `validate-snippets.yml` workflow when there are changes in the `snippets` folder.
- Cancel pending runs of `validate-snippets.yml` when a new run is added to the queue.
- Remove `merge_group` triggers, since we don't use the merge queue.