### PR TITLE
Update `publish-javadoc.yml` workflow to use `ubuntu-latest`

### DIFF
--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   publish-javadoc:
     name: Publish javadoc
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Extract Robolectric version


### PR DESCRIPTION
Update the `publish-javadoc.yml` workflow to run on `ubuntu-latest` instead of `ubuntu-22.04`.