### PR TITLE
Fix blog post title formatting

### DIFF
--- a/docs/blog/posts/2018-10-25-robolectric-4-0.md
+++ b/docs/blog/posts/2018-10-25-robolectric-4-0.md
@@ -5,10 +5,8 @@ authors:
   - brettchabot
   - xian
 slug: robolectric-4-0
+title: Robolectric 4.0 Released!
 ---
-
-<!-- markdownlint-disable-next-line MD026 -->
-# Robolectric 4.0 Released!
 
 Robolectric 4.0 is released! Here's what's new!
 


### PR DESCRIPTION
This is the same issue as #348.

I went through every blog post to see if an other one had this issue, but it looks good.

| Before | After |
|--------|--------|
| <img width="384" alt="Screenshot 2024-12-03 at 15 33 41" src="https://github.com/user-attachments/assets/090b80a4-e698-4bb1-a3db-9a0e67edec29"> | <img width="384" alt="Screenshot 2024-12-03 at 15 34 17" src="https://github.com/user-attachments/assets/ac059d48-3a6d-4a2e-951a-0efc8836dedb"> |