### PR TITLE
Remove outdated `not_in_nav` config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,9 +151,6 @@ nav:
 exclude_docs: |
   /javadoc/*/legal/jquery*.md
 
-not_in_nav: |
-  automated-migration.md
-
 validation:
   links:
     anchors: warn


### PR DESCRIPTION
Since #368 was merged, `automated-migration.md` is available in the navigation, under `Resources`.

The `not_in_nav` MkDocs configuration option is no longer needed.