### PR TITLE
Update the blog layout overrides

### DIFF
--- a/overrides/blog-post.html
+++ b/overrides/blog-post.html
@@ -1,23 +1,23 @@
 <!--
-    Copyright (c) 2016-2024 Martin Donath <martin.donath@squidfunk.com>
+  Copyright (c) 2016-2025 Martin Donath <martin.donath@squidfunk.com>
 
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to
-    deal in the Software without restriction, including without limitation the
-    rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
-    sell copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
 
-    The above copyright notice and this permission notice shall be included in
-    all copies or substantial portions of the Software.
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
 
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-    IN THE SOFTWARE.
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
 -->
 
 {% extends "main.html" %}
@@ -26,180 +26,203 @@
 
 <!-- Page content -->
 {% block container %}
-    <div class="md-content md-content--post" data-md-component="content">
+<div class="md-content md-content--post" data-md-component="content">
 
-        <!-- Sidebar -->
-        <div
+    <!-- Sidebar -->
+    <div
             class="md-sidebar md-sidebar--post"
             data-md-component="sidebar"
             data-md-type="navigation"
-        >
-            <div class="md-sidebar__scrollwrap">
-                <div class="md-sidebar__inner md-post">
-                    <nav class="md-nav md-nav--primary">
+    >
+        <div class="md-sidebar__scrollwrap">
+            <div class="md-sidebar__inner md-post">
+                <nav class="md-nav md-nav--primary">
 
-                        <!-- Back to overview link -->
-                        <div class="md-post__back">
-                            <div class="md-nav__title md-nav__container">
-                                <a href="{{ page.parent.url | url }}" class=" md-nav__link">
-                                    {% include ".icons/material/arrow-left.svg" %}
-                                    <span class="md-ellipsis">
-                                        {{ lang.t("blog.index") }}
-                                    </span>
-                                </a>
-                            </div>
+                    <!-- Back to overview link -->
+                    <div class="md-post__back">
+                        <div class="md-nav__title md-nav__container">
+                            <a href="{{ page.parent.url | url }}" class=" md-nav__link">
+                                {% include ".icons/material/arrow-left.svg" %}
+                                <span class="md-ellipsis">
+                    {{ lang.t("blog.index") }}
+                  </span>
+                            </a>
                         </div>
+                    </div>
 
-                        <!-- Post authors -->
-                        {% if page.authors %}
-                            <div class="md-post__authors md-typeset">
-                                {% for author in page.authors %}
-                                    <div class="md-profile md-post__profile">
-                                        <span class="md-author md-author--long">
-                                            <img src="{{ author.avatar }}" alt="{{ author.name }}" />
-                                        </span>
-                                        <span class="md-profile__description">
-                                            <strong>
-                                                {% if author.url %}
-                                                    <a href="{{ author.url }}">{{ author.name }}</a>
-                                                {% else %}
-                                                    {{ author.name }}
-                                                {% endif %}
-                                            </strong>
-                                            <br />
-                                            {{ author.description }}
-                                        </span>
-                                    </div>
-                                {% endfor %}
-                            </div>
+                    <!-- Post authors -->
+                    {% if page.authors %}
+                    <div class="md-post__authors md-typeset">
+                        {% for author in page.authors %}
+                        <div class="md-profile md-post__profile">
+                    <span class="md-author md-author--long">
+                      <img src="{{ author.avatar | url }}" alt="{{ author.name }}"/>
+                    </span>
+                            <span class="md-profile__description">
+                      <strong>
+                        {% if author.url %}
+                          <a href="{{ author.url | url }}">{{ author.name }}</a>
+                        {% else %}
+                          {{ author.name }}
                         {% endif %}
+                      </strong>
+                      <br/>
+                      {{ author.description }}
+                    </span>
+                        </div>
+                        {% endfor %}
+                    </div>
+                    {% endif %}
 
-                        <!-- Post metadata -->
-                        <ul class="md-post__meta md-nav__list">
-                            <li class="md-nav__item md-nav__item--section">
-                                <div class="md-post__title">
-                                    <span class="md-ellipsis">
-                                        {{ lang.t("blog.meta") }}
-                                    </span>
-                                </div>
-                                <nav class="md-nav">
-                                    <ul class="md-nav__list">
+                    <!-- Post metadata -->
+                    <ul class="md-post__meta md-nav__list">
+                        <li class="md-nav__item md-nav__item--section">
+                            <div class="md-post__title">
+                  <span class="md-ellipsis">
+                    {{ lang.t("blog.meta") }}
+                  </span>
+                            </div>
+                            <nav class="md-nav">
+                                <ul class="md-nav__list">
 
-                                        <!-- Post date -->
-                                        <li class="md-nav__item">
-                                            <div class="md-nav__link">
-                                                {% include ".icons/material/calendar.svg" %}
-                                                <time
+                                    <!-- Post date -->
+                                    <li class="md-nav__item">
+                                        <div class="md-nav__link">
+                                            {% include ".icons/material/calendar.svg" %}
+                                            <time
                                                     datetime="{{ page.config.date.created }}"
                                                     class="md-ellipsis"
-                                                >
-                                                    {{- page.config.date.created | date -}}
-                                                </time>
-                                            </div>
-                                        </li>
+                                            >
+                                                {{- page.config.date.created | date -}}
+                                            </time>
+                                        </div>
+                                    </li>
 
-                                        <!-- Post date updated -->
-                                        {% if page.config.date.updated %}
-                                            <li class="md-nav__item">
-                                                <div class="md-nav__link">
-                                                    {% include ".icons/material/calendar-clock.svg" %}
-                                                    <time
-                                                        datetime="{{ page.config.date.updated }}"
-                                                        class="md-ellipsis"
-                                                    >
-                                                        {{- page.config.date.updated | date -}}
-                                                    </time>
-                                                </div>
-                                            </li>
-                                        {% endif %}
+                                    <!-- Post date updated -->
+                                    {% if page.config.date.updated %}
+                                    <li class="md-nav__item">
+                                        <div class="md-nav__link">
+                                            {% include ".icons/material/calendar-clock.svg" %}
+                                            <time
+                                                    datetime="{{ page.config.date.updated }}"
+                                                    class="md-ellipsis"
+                                            >
+                                                {{- page.config.date.updated | date -}}
+                                            </time>
+                                        </div>
+                                    </li>
+                                    {% endif %}
 
-                                        <!-- Post categories -->
-                                        {% if page.categories %}
-                                            <li class="md-nav__item">
-                                                <div class="md-nav__link">
-                                                    {% include ".icons/material/bookshelf.svg" %}
-                                                    <span class="md-ellipsis">
-                                                        {{ lang.t("blog.categories.in") }}
-                                                        {% for category in page.categories %}
-                                                            <a href="{{ category.url | url }}">
-                                                                {{- category.title -}}
-                                                            </a>
-                                                            {%- if loop.revindex > 1 %}, {% endif -%}
-                                                        {% endfor -%}
-                                                    </span>
-                                                </div>
-                                            </li>
-                                        {% endif %}
+                                    <!-- Post categories -->
+                                    {% if page.categories %}
+                                    <li class="md-nav__item">
+                                        <div class="md-nav__link">
+                                            {% include ".icons/material/bookshelf.svg" %}
+                                            <span class="md-ellipsis">
+                            {{ lang.t("blog.categories.in") }}
+                            {% for category in page.categories %}
+                              <a href="{{ category.url | url }}">
+                                {{- category.title -}}
+                              </a>
+                              {%- if loop.revindex > 1 %}, {% endif -%}
+                            {% endfor -%}
+                          </span>
+                                        </div>
+                                    </li>
+                                    {% endif %}
 
-                                        <!-- Post readtime -->
-                                        {% if page.config.readtime %}
-                                            {% set time = page.config.readtime %}
-                                            <li class="md-nav__item">
-                                                <div class="md-nav__link">
-                                                    {% include ".icons/material/clock-outline.svg" %}
-                                                    <span class="md-ellipsis">
-                                                        {% if time == 1 %}
-                                                            {{ lang.t("readtime.one") }}
-                                                        {% else %}
-                                                            {{ lang.t("readtime.other") | replace("#", time) }}
-                                                        {% endif %}
-                                                    </span>
-                                                </div>
-                                            </li>
-                                        {% endif %}
-                                    </ul>
-                                </nav>
-                            </li>
-                        </ul>
-                    
-                        <!-- START Robolectric modification -->
-                        <!-- Share post -->
-                        <ul class="md-post__meta md-nav__list">
-                            <li class="md-nav__item md-nav__item--section">
-                                <div class="md-post__title">
-                                    <span class="md-ellipsis">
-                                        Share
-                                    </span>
-                                </div>
-                                <nav class="md-nav">
-                                    <ul class="md-nav__list md-typeset">
-                                        <li class="md-nav__item">
-                                            <div class="md-nav__link">
-                                                {% include ".icons/fontawesome/brands/x-twitter.svg" %}
-                                                <span class="md-ellipsis">
-                                                    <a href="https://x.com/intent/tweet?text={{ page.title }}&url={{ config.site_url }}{{ page.url }}&via=robolectric" rel="nofollow" target="_blank" title="Share on X">Share on X</a>
-                                                </span>
-                                            </div>
-                                        </li>
+                                    <!-- Post readtime -->
+                                    {% if page.config.readtime %}
+                                    {% set time = page.config.readtime %}
+                                    <li class="md-nav__item">
+                                        <div class="md-nav__link">
+                                            {% include ".icons/material/clock-outline.svg" %}
+                                            <span class="md-ellipsis">
+                            {% if time == 1 %}
+                              {{ lang.t("readtime.one") }}
+                            {% else %}
+                              {{ lang.t("readtime.other") | replace("#", time) }}
+                            {% endif %}
+                          </span>
+                                        </div>
+                                    </li>
+                                    {% endif %}
+                                </ul>
+                            </nav>
+                        </li>
+                    </ul>
 
-                                        <li class="md-nav__item">
-                                            <div class="md-nav__link">
-                                                {% include ".icons/fontawesome/brands/facebook.svg" %}
-                                                <span class="md-ellipsis">
-                                                    <a href="https://facebook.com/sharer.php?u={{ config.site_url }}{{ page.url }}" rel="nofollow" target="_blank" title="Share on Facebook">Share on Facebook</a>
-                                                </span>
-                                            </div>
-                                        </li>
-                                    </ul>
-                                </nav>
-                            </li>
-                        </ul>
-                        <!-- END Robolectric modification -->
-                    </nav>
+                    <!-- Related links -->
+                    {% if page.config.links %}
+                    <ul class="md-post__meta md-nav__list">
+                        <li class="md-nav__item md-nav__item--section">
+                            <div class="md-post__title">
+                                <span class="md-ellipsis">
+                                  {{ lang.t("blog.references") }}
+                                </span>
+                            </div>
 
-                    <!-- Table of contents, if integrated -->
-                    {% if "toc.integrate" in features %}
-                        {% include "partials/toc.html" %}
+                            <!-- Render related links -->
+                            <nav class="md-nav">
+                                <ul class="md-nav__list">
+                                    {% for nav_item in page.config.links %}
+                                    {% set path = "__ref_" ~ loop.index %}
+                                    {{ item.render(nav_item, path, 1) }}
+                                    {% endfor %}
+                                </ul>
+                            </nav>
+                        </li>
+                    </ul>
                     {% endif %}
-                </div>
+
+                    <!-- START Robolectric modification -->
+                    <!-- Share post -->
+                    <ul class="md-post__meta md-nav__list">
+                        <li class="md-nav__item md-nav__item--section">
+                            <div class="md-post__title">
+                                <span class="md-ellipsis">
+                                    Share
+                                </span>
+                            </div>
+                            <nav class="md-nav">
+                                <ul class="md-nav__list md-typeset">
+                                    <li class="md-nav__item">
+                                        <div class="md-nav__link">
+                                            {% include ".icons/fontawesome/brands/x-twitter.svg" %}
+                                            <span class="md-ellipsis">
+                                                <a href="https://x.com/intent/tweet?text={{ page.title }}&url={{ config.site_url }}{{ page.url }}&via=robolectric" rel="nofollow" target="_blank" title="Share on X">Share on X</a>
+                                            </span>
+                                        </div>
+                                    </li>
+
+                                    <li class="md-nav__item">
+                                        <div class="md-nav__link">
+                                            {% include ".icons/fontawesome/brands/facebook.svg" %}
+                                            <span class="md-ellipsis">
+                                                <a href="https://facebook.com/sharer.php?u={{ config.site_url }}{{ page.url }}" rel="nofollow" target="_blank" title="Share on Facebook">Share on Facebook</a>
+                                            </span>
+                                        </div>
+                                    </li>
+                                </ul>
+                            </nav>
+                        </li>
+                    </ul>
+                    <!-- END Robolectric modification -->
+                </nav>
+
+                <!-- Table of contents, if integrated -->
+                {% if "toc.integrate" in features %}
+                {% include "partials/toc.html" %}
+                {% endif %}
             </div>
         </div>
-
-        <!-- Page content -->
-        <article class="md-content__inner md-typeset">
-            {% block content %}
-                {% include "partials/content.html" %}
-            {% endblock %}
-        </article>
     </div>
+
+    <!-- Page content -->
+    <article class="md-content__inner md-typeset">
+        {% block content %}
+        {% include "partials/content.html" %}
+        {% endblock %}
+    </article>
+</div>
 {% endblock %}

--- a/overrides/partials/post.html
+++ b/overrides/partials/post.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016-2024 Martin Donath <martin.donath@squidfunk.com>
+  Copyright (c) 2016-2025 Martin Donath <martin.donath@squidfunk.com>
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to
@@ -22,84 +22,84 @@
 
 <!-- Post excerpt -->
 <article class="md-post md-post--excerpt">
-  <header class="md-post__header">
+    <header class="md-post__header">
 
-    <!-- Post authors -->
-    {% if post.authors %}
-      <nav class="md-post__authors md-typeset">
-        {% for author in post.authors %}
-          <span class="md-author">
-            <img src="{{ author.avatar }}" alt="{{ author.name }}" />
+        <!-- Post authors -->
+        {% if post.authors %}
+        <nav class="md-post__authors md-typeset">
+            {% for author in post.authors %}
+            <span class="md-author">
+            <img src="{{ author.avatar | url }}" alt="{{ author.name }}"/>
           </span>
-        {% endfor %}
-      </nav>
-    {% endif %}
+            {% endfor %}
+        </nav>
+        {% endif %}
 
-    <!-- Post metadata -->
-    <div class="md-post__meta md-meta">
-        <ul class="md-meta__list">
+        <!-- Post metadata -->
+        <div class="md-post__meta md-meta">
+            <ul class="md-meta__list">
 
-            <!-- Post date -->
-            <li class="md-meta__item">
-                <time datetime="{{ post.config.date.created }}">
-                    {{- post.config.date.created | date -}}
-                </time>
-                {#- Collapse whitespace -#}
-            </li>
+                <!-- Post date -->
+                <li class="md-meta__item">
+                    <time datetime="{{ post.config.date.created }}">
+                        {{- post.config.date.created | date -}}
+                    </time>
+                    {#- Collapse whitespace -#}
+                </li>
 
-            <!-- Post categories -->
-            {% if post.categories %}
+                <!-- Post categories -->
+                {% if post.categories %}
                 <li class="md-meta__item">
                     {{ lang.t("blog.categories.in") }}
                     {% for category in post.categories %}
-                        <a
+                    <a
                             href="{{ category.url | url }}"
                             class="md-meta__link"
-                        >
-                            {{- category.title -}}
-                        </a>
-                        {%- if loop.revindex > 1 %}, {% endif -%}
+                    >
+                        {{- category.title -}}
+                    </a>
+                    {%- if loop.revindex > 1 %}, {% endif -%}
                     {% endfor -%}
                 </li>
-            {% endif %}
+                {% endif %}
 
-            <!-- Post readtime -->
-            {% if post.config.readtime %}
+                <!-- Post readtime -->
+                {% if post.config.readtime %}
                 {% set time = post.config.readtime %}
                 <li class="md-meta__item">
                     {% if time == 1 %}
-                        {{ lang.t("readtime.one") }}
+                    {{ lang.t("readtime.one") }}
                     {% else %}
-                        {{ lang.t("readtime.other") | replace("#", time) }}
+                    {{ lang.t("readtime.other") | replace("#", time) }}
                     {% endif %}
                 </li>
-            {% endif %}
-        </ul>
+                {% endif %}
+            </ul>
 
-        <!-- Draft marker -->
-        {% if post.config.draft %}
+            <!-- Draft marker -->
+            {% if post.config.draft %}
             <span class="md-draft">
-                {{ lang.t("blog.draft") }}
-            </span>
-        {% endif %}
-    </div>
-  </header>
+          {{ lang.t("blog.draft") }}
+        </span>
+            {% endif %}
+        </div>
+    </header>
 
-  <!-- Post content -->
-  <div class="md-post__content md-typeset">
-    <!-- START Robolectric modification -->
-    {% set post_content = post.md.convert(post.markdown) %}
-    
-    {{ post_content.split("</p>", 1)[0] }}</p>
-    <!-- END Robolectric modification -->
-        
-    <!-- Continue reading link -->
-    {% if post.more %}
+    <!-- Post content -->
+    <div class="md-post__content md-typeset">
+        <!-- START Robolectric modification -->
+        {% set post_content = post.md.convert(post.markdown) %}
+
+        {{ post_content.split("</p>", 1)[0] }}</p>
+        <!-- END Robolectric modification -->
+
+        <!-- Continue reading link -->
+        {% if post.more %}
         <nav class="md-post__action">
             <a href="{{ post.url | url }}">
                 {{ lang.t("blog.continue") }}
             </a>
         </nav>
-    {% endif %}
-  </div>
+        {% endif %}
+    </div>
 </article>


### PR DESCRIPTION
This PR updates the `blog-post.html` and `post.html` layout overrides following the recent update of Mkdocs Material to 9.6.0.

The main change is the addition of ["Related links"](https://squidfunk.github.io/mkdocs-material/tutorials/blogs/basic/#related-links) to the `blog-post.html` layout.

https://github.com/squidfunk/mkdocs-material/blob/9.6.4/src/templates/blog-post.html
https://github.com/squidfunk/mkdocs-material/blob/9.6.4/src/templates/partials/post.html

**Note:** the indentation of the files has changed. I recommend using the ["Hide whitespace changes"](https://github.com/robolectric/robolectric.github.io/pull/401/files?w=1) option for an easier review.