### PR TITLE
Increase PR limit for Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,5 +18,6 @@
       "matchManagers": "gradle",
       "sourceDirectory": "snippets"
     }
-  ]
+  ],
+  "prHourlyLimit": 5
 }


### PR DESCRIPTION
Currently, Renovate only creates at most 2 PRs per hour.
But often, we have 4/5 dependencies to update per week.
With this, we have more PR automatically suggested, without any manual action.