### PR TITLE
Update GitHub Token for the `publish-javadoc.yml` workflow

### DIFF
--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Create Pull Request
         if: ${{ steps.robolectric_version.outputs.patchVersion }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.ROBOLECTRIC_PAT }}
         run: |
           cd robolectric.github.io
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
This commit changes the GitHub Token of the `publish-javadoc.yml` workflow to use a custom. Hopefully, this will allow the generated PR to have its workflow to run.