### PR TITLE
Publish javadoc for Robolectric 4.15

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,7 @@ nav:
     - "Upgrade to Robolectric 3.x": upgrade_to_version_3.md
     - "Javadoc":
       - "4.15": /javadoc/4.15/
+      - "4.15": /javadoc/4.15/
       - "4.14": /javadoc/4.14/
       - "4.13": /javadoc/4.13/
       - "4.12": /javadoc/4.12/


### PR DESCRIPTION
- Add javadoc for Robolectric 4.15.

- Update mkdocs.yml to add a navigation entry to the new javadoc.

- Update mkdocs.yml to use version 4.15.

Fixes #452
