### PR TITLE
Use Java 21 for the Javadoc publication workflow

### DIFF
--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -45,12 +45,12 @@ jobs:
         with:
           path: robolectric.github.io
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         if: ${{ steps.robolectric_version.outputs.minorVersion }}
         with:
           distribution: 'adopt'
-          java-version: 17
+          java-version: 21
 
       - name: Assemble and aggregate javadoc
         if: ${{ steps.robolectric_version.outputs.minorVersion }}


### PR DESCRIPTION
Java 21 is now required for the Javadoc publication workflow.
See https://github.com/robolectric/robolectric.github.io/actions/runs/17221655200.