### PR TITLE
Fix version replacement in `publish-javadoc.yml`

### DIFF
--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -73,7 +73,7 @@ jobs:
         if: ${{ steps.robolectric_version.outputs.patchVersion }}
         run: |
           cd robolectric.github.io
-          sed -i 's/^      current: ".*"$/      current: "${{ steps.robolectric_version.outputs.patchVersion }}"/' mkdocs.yml
+          perl -i -0777 -pe 's/(robolectric:\s*version:\s*current: )".*"/\1"${{ steps.robolectric_version.outputs.patchVersion }}"/' mkdocs.yml
           sed -i 's/^\(    - "Javadoc":\)$/\1\n      - "${{ steps.robolectric_version.outputs.patchVersion }}": \/javadoc\/${{ steps.robolectric_version.outputs.patchVersion }}\//' mkdocs.yml
 
       - name: Update latest javadoc symbolic link


### PR DESCRIPTION
The current logic was naively updating lines that start with `current: `.
Now that we also have the simulator, this is no longer enough, because the command updates both Robolectric and the simulator versions.
This commit improves the logic to only change Robolectric's version.

-----

**Note:** this could simply have been ` yq -i '.extra.robolectric.version.current = "4.16"' mkdocs.yml`. But it seems that `yq` reformats the file (in our case, removes all the blank lines) when modifying it.