### PR TITLE
Fix repository name is the PR preview step

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1
-        if: ${{ github.repository == 'robolectric/robolectric' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == 'robolectric/robolectric.github.io' }}
         with:
           source-dir: site
           pages-base-url: robolectric.org


### PR DESCRIPTION
The step was executed only if the repository is `robolectric/robolectric`, which is wrong.
The check should be for the `robolectric/robolectric.github.io` repository.