### PR TITLE
Document using --add-opens flags.

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -71,6 +71,60 @@ class SandwichTest
 
 ///
 
+### Running with Java 17 and higher
+
+When running tests on Java 17 or higher, the JVM requires `--add-opens` flags so that Robolectric can access internal
+OpenJDK classes and APIs (`java.lang`, `java.io`, `jdk.internal.access`, etc.). Add the following `jvmArgs` to your
+unit test configuration in `build.gradle` / `build.gradle.kts`:
+
+/// tab | Groovy
+
+```groovy
+android {
+  testOptions {
+    unitTests.all {
+      jvmArgs += [
+        "--add-opens=java.base/java.lang=ALL-UNNAMED",
+        "--add-opens=java.base/java.util=ALL-UNNAMED",
+        "--add-opens=java.base/java.io=ALL-UNNAMED",
+        "--add-opens=java.base/java.net=ALL-UNNAMED",
+        "--add-opens=java.base/java.security=ALL-UNNAMED",
+        "--add-opens=java.base/java.text=ALL-UNNAMED",
+        "--add-opens=java.base/jdk.internal.access=ALL-UNNAMED",
+        "--add-opens=java.desktop/java.awt.font=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+      ]
+    }
+  }
+}
+```
+
+///
+
+/// tab | Kotlin
+
+```kotlin
+android {
+  testOptions {
+    unitTests.all {
+      jvmArgs(
+        "--add-opens=java.base/java.lang=ALL-UNNAMED",
+        "--add-opens=java.base/java.util=ALL-UNNAMED",
+        "--add-opens=java.base/java.io=ALL-UNNAMED",
+        "--add-opens=java.base/java.net=ALL-UNNAMED",
+        "--add-opens=java.base/java.security=ALL-UNNAMED",
+        "--add-opens=java.base/java.text=ALL-UNNAMED",
+        "--add-opens=java.base/jdk.internal.access=ALL-UNNAMED",
+        "--add-opens=java.desktop/java.awt.font=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+      )
+    }
+  }
+}
+```
+
+///
+
 ## Building with Bazel
 
 Robolectric works with [Bazel][bazel] 0.10.0 or higher. Bazel integrates with Robolectric through


### PR DESCRIPTION
This is necessary to avoid errors like
```
org.robolectric.interceptors.AndroidInterceptors$FileDescriptorInterceptor cannot access class jdk.internal.access.SharedSecrets (in module java.base) because module java.base does not export jdk.internal.access to unnamed module
```