### PR TITLE
Enable Gradle caching for the snippets project

### DIFF
--- a/snippets/gradle.properties
+++ b/snippets/gradle.properties
@@ -8,10 +8,27 @@
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 
+# Enable Gradle's Build Cache
+# https://docs.gradle.org/current/userguide/performance.html#enable_the_build_cache
+org.gradle.caching=true
+
+# Enable Gradle's Configuration Cache
+# https://docs.gradle.org/current/userguide/performance.html#enable_configuration_cache
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true
+
+# Enable Gradle's Configuration on Demand
+# https://docs.gradle.org/current/userguide/configuration_on_demand.html
+org.gradle.configureondemand=true
+
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
 org.gradle.parallel=true
+
+# Enable Gradle's parallelism for the Tooling API
+# https://docs.gradle.org/current/userguide/performance.html#sec:configure_tooling_api_actions_parallelism
+org.gradle.tooling.parallel=true
 
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK


### PR DESCRIPTION
This PR enables various Gradle caching and optimization features:
- Build Cache
- Configuration Cache (and its parallel mode)
- Configuration on Demand
- Parallel Tooling API