### PR TITLE
Add Java version per SDK and max SDK per Robolectric version

### DIFF
--- a/docs/compatibility_table.md
+++ b/docs/compatibility_table.md
@@ -1,27 +1,49 @@
----
-hide:
-  - toc
----
-
 # Compatibility Table
 
-| Robolectric version | Min SDK version | Gradle version | Android Gradle Plugin version |
-|---------------------|-----------------|----------------|-------------------------------|
-| 4.16                | 23              | 8.14.3         | 8.12.0                        |
-| 4.15                | 21              | 8.14.1         | 8.10.1                        |
-| 4.14                | 21              | 8.10.2         | 8.7.1                         |
-| 4.13                | 21              | 8.8            | 8.5.0                         |
-| 4.12                | 19              | 8.7            | 8.3.1                         |
-| 4.11                | 16              | 8.3            | 8.1.2                         |
-| 4.10                | 16              | 7.6            | 7.4.2                         |
-| 4.9                 | 16              | 7.4.2          | 7.3.0                         |
-| 4.8                 | 16              | 7.4.2          | 7.1.0                         |
-| 4.7                 | 16              | 7.2            | 7.1.0-beta03                  |
-| 4.6                 | 16              | 6.8            | 4.1.3                         |
-| 4.5                 | 16              | 6.6.1          | 4.1.1                         |
-| 4.4                 | 16              | 5.4.1          | 3.5.3                         |
-| 4.3                 | 16              | 4.10.3         | 3.3.1                         |
-| 4.2                 | 16              | 5.1.1          | 3.4.0-beta03                  |
-| 4.1                 | 16              | 4.10.2         | 3.2.1                         |
-| 4.0.2               | 16              | 4.10.2         | 3.2.1                         |
-| 4.0                 | 16              | 4.10.2         | 3.1.2                         |
+## Robolectric
+
+This table shows the minimum and maximum Android SDK versions per Robolectric release, as well as the versions of Gradle
+and the Android Gradle Plugin used to build Robolectric.
+
+| Robolectric version | Android API levels | Gradle version | Android Gradle Plugin version |
+|---------------------|--------------------|----------------|-------------------------------|
+| 4.16                | 23 → 36            | 8.14.3         | 8.12.0                        |
+| 4.15                | 21 → 35            | 8.14.1         | 8.10.1                        |
+| 4.14                | 21 → 35            | 8.10.2         | 8.7.1                         |
+| 4.13                | 21 → 34            | 8.8            | 8.5.0                         |
+| 4.12                | 19 → 34            | 8.7            | 8.3.1                         |
+| 4.11                | 16 → 34            | 8.3            | 8.1.2                         |
+| 4.10                | 16 → 33            | 7.6            | 7.4.2                         |
+| 4.9                 | 16 → 33            | 7.4.2          | 7.3.0                         |
+| 4.8                 | 16 → 32            | 7.4.2          | 7.1.0                         |
+| 4.7                 | 16 → 31            | 7.2            | 7.1.0-beta03                  |
+| 4.6                 | 16 → 30            | 6.8            | 4.1.3                         |
+| 4.5                 | 16 → 30            | 6.6.1          | 4.1.1                         |
+| 4.4                 | 16 → 29            | 5.4.1          | 3.5.3                         |
+| 4.3                 | 16 → 29            | 4.10.3         | 3.3.1                         |
+| 4.2                 | 16 → 28            | 5.1.1          | 3.4.0-beta03                  |
+| 4.1                 | 16 → 28            | 4.10.2         | 3.2.1                         |
+| 4.0.2               | 16 → 28            | 4.10.2         | 3.2.1                         |
+| 4.0                 | 16 → 28            | 4.10.2         | 3.1.2                         |
+
+## Android
+
+This table shows the minimum Java version required to run Robolectric tests against a specific version of Android.
+
+| Android version | API level | Java version |
+|-----------------|-----------|--------------|
+| Android 17      | 37        | 21           |
+| Android 16      | 36        | 21           |
+| Android 15      | 35        | 17           |
+| Android 14      | 34        | 17           |
+| Android 13      | 33        | 9            |
+| Android 12.1    | 32        | 9            |
+| Android 12      | 31        | 9            |
+| Android 11      | 30        | 9            |
+| Android 10      | 29        | 9            |
+| Android 9       | 28        | 8            |
+| Android 8.1     | 27        | 8            |
+| Android 8.0     | 26        | 8            |
+| Android 7.1     | 25        | 8            |
+| Android 7.0     | 24        | 8            |
+| Android 6.0     | 23        | 8            |


### PR DESCRIPTION
This PR follows-up on #635.

The updated page can be seen here: https://robolectric.org/pr-preview/pr-638/compatibility_table/