### PR TITLE
Switch `actions/setup-java` from `adopt` to `temurin`

### DIFF
--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/setup-java@v5
         if: ${{ steps.robolectric_version.outputs.minorVersion }}
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 21
 
       - name: Assemble and aggregate javadoc

--- a/.github/workflows/validate-snippets.yml
+++ b/.github/workflows/validate-snippets.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 21
 
       - name: Setup Gradle


### PR DESCRIPTION
The former is not updated anymore, and should be replaced by the latter.
See the [official documentation](https://github.com/actions/setup-java#supported-distributions).
<img width="784" height="78" alt="Screenshot 2026-07-27 at 07 23 32" src="https://github.com/user-attachments/assets/523cd5b2-79f7-4859-81a4-4b261a04beaf" />