### PR TITLE
Let Renovate create PRs as soon as possible

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,8 +27,7 @@
   ],
   "extends": [
     "config:recommended",
-    ":disableDependencyDashboard",
-    "schedule:weekly"
+    ":disableDependencyDashboard"
   ],
   "labels": [
     "dependencies"


### PR DESCRIPTION
I'd say that it's fine on this project to have PR to update dependencies created immediately.
Since we don't ship any library, and we have PR preview, we can easily validate the change.
